### PR TITLE
IDE-2808-mor: adjustments in Xsemantics for initial contribution

### DIFF
--- a/EPL-1.0.html
+++ b/EPL-1.0.html
@@ -1,0 +1,260 @@
+<!--?xml version="1.0" encoding="ISO-8859-1" ?-->
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"><head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>Eclipse Public License - Version 1.0</title>
+<style type="text/css">
+  body {
+    size: 8.5in 11.0in;
+    margin: 0.25in 0.5in 0.25in 0.5in;
+    tab-interval: 0.5in;
+    }
+  p {  	
+    margin-left: auto;
+    margin-top:  0.5em;
+    margin-bottom: 0.5em;
+    }
+  p.list {
+  	margin-left: 0.5in;
+    margin-top:  0.05em;
+    margin-bottom: 0.05em;
+    }
+  </style>
+
+</head>
+
+<body lang="EN-US">
+
+<h2>Eclipse Public License - v 1.0</h2>
+
+<p>THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR
+DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS
+AGREEMENT.</p>
+
+<p><b>1. DEFINITIONS</b></p>
+
+<p>"Contribution" means:</p>
+
+<p class="list">a) in the case of the initial Contributor, the initial
+code and documentation distributed under this Agreement, and</p>
+<p class="list">b) in the case of each subsequent Contributor:</p>
+<p class="list">i) changes to the Program, and</p>
+<p class="list">ii) additions to the Program;</p>
+<p class="list">where such changes and/or additions to the Program
+originate from and are distributed by that particular Contributor. A
+Contribution 'originates' from a Contributor if it was added to the
+Program by such Contributor itself or anyone acting on such
+Contributor's behalf. Contributions do not include additions to the
+Program which: (i) are separate modules of software distributed in
+conjunction with the Program under their own license agreement, and (ii)
+are not derivative works of the Program.</p>
+
+<p>"Contributor" means any person or entity that distributes
+the Program.</p>
+
+<p>"Licensed Patents" mean patent claims licensable by a
+Contributor which are necessarily infringed by the use or sale of its
+Contribution alone or when combined with the Program.</p>
+
+<p>"Program" means the Contributions distributed in accordance
+with this Agreement.</p>
+
+<p>"Recipient" means anyone who receives the Program under
+this Agreement, including all Contributors.</p>
+
+<p><b>2. GRANT OF RIGHTS</b></p>
+
+<p class="list">a) Subject to the terms of this Agreement, each
+Contributor hereby grants Recipient a non-exclusive, worldwide,
+royalty-free copyright license to reproduce, prepare derivative works
+of, publicly display, publicly perform, distribute and sublicense the
+Contribution of such Contributor, if any, and such derivative works, in
+source code and object code form.</p>
+
+<p class="list">b) Subject to the terms of this Agreement, each
+Contributor hereby grants Recipient a non-exclusive, worldwide,
+royalty-free patent license under Licensed Patents to make, use, sell,
+offer to sell, import and otherwise transfer the Contribution of such
+Contributor, if any, in source code and object code form. This patent
+license shall apply to the combination of the Contribution and the
+Program if, at the time the Contribution is added by the Contributor,
+such addition of the Contribution causes such combination to be covered
+by the Licensed Patents. The patent license shall not apply to any other
+combinations which include the Contribution. No hardware per se is
+licensed hereunder.</p>
+
+<p class="list">c) Recipient understands that although each Contributor
+grants the licenses to its Contributions set forth herein, no assurances
+are provided by any Contributor that the Program does not infringe the
+patent or other intellectual property rights of any other entity. Each
+Contributor disclaims any liability to Recipient for claims brought by
+any other entity based on infringement of intellectual property rights
+or otherwise. As a condition to exercising the rights and licenses
+granted hereunder, each Recipient hereby assumes sole responsibility to
+secure any other intellectual property rights needed, if any. For
+example, if a third party patent license is required to allow Recipient
+to distribute the Program, it is Recipient's responsibility to acquire
+that license before distributing the Program.</p>
+
+<p class="list">d) Each Contributor represents that to its knowledge it
+has sufficient copyright rights in its Contribution, if any, to grant
+the copyright license set forth in this Agreement.</p>
+
+<p><b>3. REQUIREMENTS</b></p>
+
+<p>A Contributor may choose to distribute the Program in object code
+form under its own license agreement, provided that:</p>
+
+<p class="list">a) it complies with the terms and conditions of this
+Agreement; and</p>
+
+<p class="list">b) its license agreement:</p>
+
+<p class="list">i) effectively disclaims on behalf of all Contributors
+all warranties and conditions, express and implied, including warranties
+or conditions of title and non-infringement, and implied warranties or
+conditions of merchantability and fitness for a particular purpose;</p>
+
+<p class="list">ii) effectively excludes on behalf of all Contributors
+all liability for damages, including direct, indirect, special,
+incidental and consequential damages, such as lost profits;</p>
+
+<p class="list">iii) states that any provisions which differ from this
+Agreement are offered by that Contributor alone and not by any other
+party; and</p>
+
+<p class="list">iv) states that source code for the Program is available
+from such Contributor, and informs licensees how to obtain it in a
+reasonable manner on or through a medium customarily used for software
+exchange.</p>
+
+<p>When the Program is made available in source code form:</p>
+
+<p class="list">a) it must be made available under this Agreement; and</p>
+
+<p class="list">b) a copy of this Agreement must be included with each
+copy of the Program.</p>
+
+<p>Contributors may not remove or alter any copyright notices contained
+within the Program.</p>
+
+<p>Each Contributor must identify itself as the originator of its
+Contribution, if any, in a manner that reasonably allows subsequent
+Recipients to identify the originator of the Contribution.</p>
+
+<p><b>4. COMMERCIAL DISTRIBUTION</b></p>
+
+<p>Commercial distributors of software may accept certain
+responsibilities with respect to end users, business partners and the
+like. While this license is intended to facilitate the commercial use of
+the Program, the Contributor who includes the Program in a commercial
+product offering should do so in a manner which does not create
+potential liability for other Contributors. Therefore, if a Contributor
+includes the Program in a commercial product offering, such Contributor
+("Commercial Contributor") hereby agrees to defend and
+indemnify every other Contributor ("Indemnified Contributor")
+against any losses, damages and costs (collectively "Losses")
+arising from claims, lawsuits and other legal actions brought by a third
+party against the Indemnified Contributor to the extent caused by the
+acts or omissions of such Commercial Contributor in connection with its
+distribution of the Program in a commercial product offering. The
+obligations in this section do not apply to any claims or Losses
+relating to any actual or alleged intellectual property infringement. In
+order to qualify, an Indemnified Contributor must: a) promptly notify
+the Commercial Contributor in writing of such claim, and b) allow the
+Commercial Contributor to control, and cooperate with the Commercial
+Contributor in, the defense and any related settlement negotiations. The
+Indemnified Contributor may participate in any such claim at its own
+expense.</p>
+
+<p>For example, a Contributor might include the Program in a commercial
+product offering, Product X. That Contributor is then a Commercial
+Contributor. If that Commercial Contributor then makes performance
+claims, or offers warranties related to Product X, those performance
+claims and warranties are such Commercial Contributor's responsibility
+alone. Under this section, the Commercial Contributor would have to
+defend claims against the other Contributors related to those
+performance claims and warranties, and if a court requires any other
+Contributor to pay any damages as a result, the Commercial Contributor
+must pay those damages.</p>
+
+<p><b>5. NO WARRANTY</b></p>
+
+<p>EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS
+PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION,
+ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY
+OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely
+responsible for determining the appropriateness of using and
+distributing the Program and assumes all risks associated with its
+exercise of rights under this Agreement , including but not limited to
+the risks and costs of program errors, compliance with applicable laws,
+damage to or loss of data, programs or equipment, and unavailability or
+interruption of operations.</p>
+
+<p><b>6. DISCLAIMER OF LIABILITY</b></p>
+
+<p>EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT
+NOR ANY CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING
+WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OR
+DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED
+HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.</p>
+
+<p><b>7. GENERAL</b></p>
+
+<p>If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of
+the remainder of the terms of this Agreement, and without further action
+by the parties hereto, such provision shall be reformed to the minimum
+extent necessary to make such provision valid and enforceable.</p>
+
+<p>If Recipient institutes patent litigation against any entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that the
+Program itself (excluding combinations of the Program with other
+software or hardware) infringes such Recipient's patent(s), then such
+Recipient's rights granted under Section 2(b) shall terminate as of the
+date such litigation is filed.</p>
+
+<p>All Recipient's rights under this Agreement shall terminate if it
+fails to comply with any of the material terms or conditions of this
+Agreement and does not cure such failure in a reasonable period of time
+after becoming aware of such noncompliance. If all Recipient's rights
+under this Agreement terminate, Recipient agrees to cease use and
+distribution of the Program as soon as reasonably practicable. However,
+Recipient's obligations under this Agreement and any licenses granted by
+Recipient relating to the Program shall continue and survive.</p>
+
+<p>Everyone is permitted to copy and distribute copies of this
+Agreement, but in order to avoid inconsistency the Agreement is
+copyrighted and may only be modified in the following manner. The
+Agreement Steward reserves the right to publish new versions (including
+revisions) of this Agreement from time to time. No one other than the
+Agreement Steward has the right to modify this Agreement. The Eclipse
+Foundation is the initial Agreement Steward. The Eclipse Foundation may
+assign the responsibility to serve as the Agreement Steward to a
+suitable separate entity. Each new version of the Agreement will be
+given a distinguishing version number. The Program (including
+Contributions) may always be distributed subject to the version of the
+Agreement under which it was received. In addition, after a new version
+of the Agreement is published, Contributor may elect to distribute the
+Program (including its Contributions) under the new version. Except as
+expressly stated in Sections 2(a) and 2(b) above, Recipient receives no
+rights or licenses to the intellectual property of any Contributor under
+this Agreement, whether expressly, by implication, estoppel or
+otherwise. All rights in the Program not expressly granted under this
+Agreement are reserved.</p>
+
+<p>This Agreement is governed by the laws of the State of New York and
+the intellectual property laws of the United States of America. No party
+to this Agreement will bring a legal action under this Agreement more
+than one year after the cause of action arose. Each party waives its
+rights to a jury trial in any resulting litigation.</p>
+
+
+
+
+</body></html>

--- a/devtools/it.xsemantics.targetplatform/about.html
+++ b/devtools/it.xsemantics.targetplatform/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>July 11, 2017</p>
+
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/devtools/it.xsemantics.targetplatform/plugin.properties
+++ b/devtools/it.xsemantics.targetplatform/plugin.properties
@@ -1,3 +1,3 @@
 
-pluginName = it.xsemantics.dsl
+pluginName = it.xsemantics.targetplatform
 providerName = Eclipse Xsemantics Project

--- a/devtools/it.xsemantics.targetplatform/pom.xml
+++ b/devtools/it.xsemantics.targetplatform/pom.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/devtools/it.xsemantics.workspace/Xsemantics.setup
+++ b/devtools/it.xsemantics.workspace/Xsemantics.setup
@@ -117,8 +117,7 @@
     <setupTask
         xsi:type="setup.p2:P2Task"
         id="p2.egit"
-        label="EGit"
-        licenseConfirmationDisabled="true">
+        label="EGit">
       <requirement
           name="org.eclipse.egit.feature.group"/>
       <repository
@@ -134,8 +133,7 @@
     <setupTask
         xsi:type="setup.p2:P2Task"
         id="p2.mylyn"
-        label="Mylyn"
-        licenseConfirmationDisabled="true">
+        label="Mylyn">
       <requirement
           name="org.eclipse.mylyn.bugzilla_feature.feature.group"/>
       <requirement
@@ -224,8 +222,7 @@
     <setupTask
         xsi:type="setup.p2:P2Task"
         id="p2.swtbot"
-        label="SWTBot"
-        licenseConfirmationDisabled="true">
+        label="SWTBot">
       <requirement
           name="org.eclipse.swtbot.eclipse.feature.group"/>
       <requirement
@@ -251,8 +248,7 @@
     <setupTask
         xsi:type="setup.p2:P2Task"
         id="p2.m2e"
-        label="M2E"
-        licenseConfirmationDisabled="true">
+        label="M2E">
       <requirement
           name="org.sonatype.tycho.m2e.feature.feature.group"/>
       <requirement
@@ -535,8 +531,7 @@
     <setupTask
         xsi:type="setup.p2:P2Task"
         id="p2.org.eclipse.xtext.2.10"
-        label="Xtext Releases"
-        licenseConfirmationDisabled="true">
+        label="Xtext Releases">
       <requirement
           name="org.eclipse.xtext.sdk.feature.group"
           versionRange="[2.12.0,2.13.0)"/>
@@ -563,8 +558,7 @@
     <setupTask
         xsi:type="setup.p2:P2Task"
         id="p2.org.eclipse.xtext.nightly"
-        label="Xtext Nightly"
-        licenseConfirmationDisabled="true">
+        label="Xtext Nightly">
       <requirement
           name="org.eclipse.xtext.sdk.feature.group"
           versionRange="[2.11.0,2.12.0)"/>

--- a/devtools/it.xsemantics.workspace/about.html
+++ b/devtools/it.xsemantics.workspace/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>July 11, 2017</p>
+
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/devtools/it.xsemantics.workspace/feature.xml
+++ b/devtools/it.xsemantics.workspace/feature.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <feature
       id="it.xsemantics.workspace"
       label="Xsemantics Workspace"

--- a/devtools/it.xsemantics.workspace/feature.xml
+++ b/devtools/it.xsemantics.workspace/feature.xml
@@ -13,18 +13,27 @@ Contributors:
       id="it.xsemantics.workspace"
       label="Xsemantics Workspace"
       version="1.12.1.qualifier"
-      provider-name="Lorenzo Bettini">
+      provider-name="%providerName"
+      license-feature="org.eclipse.license"
+      license-feature-version="1.0.1.v20140414-1359">
 
    <description url="http://www.example.com/description">
       [Enter Feature Description here.]
    </description>
 
-   <copyright url="http://www.example.com/copyright">
-      [Enter Copyright Description here.]
+   <copyright>
+      Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
    </copyright>
 
-   <license url="http://www.example.com/license">
-      [Enter License Description here.]
+   <license url="%licenseURL">
+      %license
    </license>
 
    <includes

--- a/devtools/it.xsemantics.workspace/plugin.properties
+++ b/devtools/it.xsemantics.workspace/plugin.properties
@@ -1,3 +1,3 @@
 
-pluginName = it.xsemantics.dsl
+pluginName = it.xsemantics.workspace
 providerName = Eclipse Xsemantics Project

--- a/doc/it.xsemantics.doc/META-INF/MANIFEST.MF
+++ b/doc/it.xsemantics.doc/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Xsemantics Documentation
 Bundle-SymbolicName: it.xsemantics.doc;singleton:=true
 Bundle-Version: 1.12.1.qualifier
-Bundle-Vendor: Lorenzo Bettini
+Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.help;bundle-version="3.5.0",
  org.eclipse.xtext.xdoc.generator;bundle-version="0.1.0";resolution:=optional,
  it.xsemantics.runtime;bundle-version="1.0.0",

--- a/doc/it.xsemantics.doc/about.html
+++ b/doc/it.xsemantics.doc/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>July 11, 2017</p>
+
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/doc/it.xsemantics.doc/contents/toc.xml
+++ b/doc/it.xsemantics.doc/contents/toc.xml
@@ -1,14 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
-Copyright (c) 2013-2017 Lorenzo Bettini.
-All rights reserved. This program and the accompanying materials
-are made available under the terms of the Eclipse Public License v1.0
-which accompanies this distribution, and is available at
-http://www.eclipse.org/legal/epl-v10.html
-
-Contributors:
-  Lorenzo Bettini - Initial contribution and API
--->
+<?xml version="1.0" encoding="ISO-8859-1" ?>
 <toc topic="contents/00-Main.html" label="Xsemantics Documentation" >
 	<topic href="contents/00-Main_12.html#Xsemantics%20Documentation_12" label="Reference Documentation" >
 		<topic href="contents/01-Introduction.html#Introduction" label="Introduction" >

--- a/doc/it.xsemantics.doc/contents/toc.xml
+++ b/doc/it.xsemantics.doc/contents/toc.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <toc topic="contents/00-Main.html" label="Xsemantics Documentation" >
 	<topic href="contents/00-Main_12.html#Xsemantics%20Documentation_12" label="Reference Documentation" >
 		<topic href="contents/01-Introduction.html#Introduction" label="Introduction" >

--- a/doc/it.xsemantics.doc/contents/toc.xml
+++ b/doc/it.xsemantics.doc/contents/toc.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <toc topic="contents/00-Main.html" label="Xsemantics Documentation" >
 	<topic href="contents/00-Main_12.html#Xsemantics%20Documentation_12" label="Reference Documentation" >
 		<topic href="contents/01-Introduction.html#Introduction" label="Introduction" >

--- a/doc/it.xsemantics.doc/plugin.properties
+++ b/doc/it.xsemantics.doc/plugin.properties
@@ -1,3 +1,3 @@
 
-pluginName = it.xsemantics.dsl
+pluginName = it.xsemantics.doc
 providerName = Eclipse Xsemantics Project

--- a/doc/it.xsemantics.doc/plugin.xml
+++ b/doc/it.xsemantics.doc/plugin.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <?eclipse version="3.4"?>
 <plugin>
    <extension

--- a/doc/it.xsemantics.doc/pom.xml
+++ b/doc/it.xsemantics.doc/pom.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/doc/it.xsemantics.doc/src/workflow/GenerateHelpArtifacts.mwe2
+++ b/doc/it.xsemantics.doc/src/workflow/GenerateHelpArtifacts.mwe2
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ *******************************************************************************/
 module GenerateHelpArtifacts
 
 import org.eclipse.emf.mwe.utils.*

--- a/doc/it.xsemantics.doc/src/workflow/GeneratePDF.mwe2
+++ b/doc/it.xsemantics.doc/src/workflow/GeneratePDF.mwe2
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ *******************************************************************************/
 module GenerateSpec
 
 import org.eclipse.emf.mwe.utils.*

--- a/examples/it.xsemantics.example.expressions.tests/META-INF/MANIFEST.MF
+++ b/examples/it.xsemantics.example.expressions.tests/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: it.xsemantics.example.expressions.tests
-Bundle-Vendor: Lorenzo Bettini
+Bundle-Vendor: %providerName
 Bundle-Version: 1.12.1.qualifier
 Bundle-SymbolicName: it.xsemantics.example.expressions.tests;singleton:=true
 Bundle-ActivationPolicy: lazy

--- a/examples/it.xsemantics.example.expressions.tests/about.html
+++ b/examples/it.xsemantics.example.expressions.tests/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>July 11, 2017</p>
+
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/examples/it.xsemantics.example.expressions.tests/plugin.properties
+++ b/examples/it.xsemantics.example.expressions.tests/plugin.properties
@@ -1,0 +1,3 @@
+
+pluginName = it.xsemantics.example.expressions.tests
+providerName = Eclipse Xsemantics Project

--- a/examples/it.xsemantics.example.expressions.tests/pom.xml
+++ b/examples/it.xsemantics.example.expressions.tests/pom.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/examples/it.xsemantics.example.expressions.ui/META-INF/MANIFEST.MF
+++ b/examples/it.xsemantics.example.expressions.ui/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Xsemantics Expression UI
-Bundle-Vendor: Lorenzo Bettini
+Bundle-Vendor: %providerName
 Bundle-Version: 1.12.1.qualifier
 Bundle-SymbolicName: it.xsemantics.example.expressions.ui;singleton:=true
 Bundle-ActivationPolicy: lazy

--- a/examples/it.xsemantics.example.expressions.ui/about.html
+++ b/examples/it.xsemantics.example.expressions.ui/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>July 11, 2017</p>
+
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/examples/it.xsemantics.example.expressions.ui/plugin.properties
+++ b/examples/it.xsemantics.example.expressions.ui/plugin.properties
@@ -1,0 +1,3 @@
+
+pluginName = it.xsemantics.example.expressions.ui
+providerName = Eclipse Xsemantics Project

--- a/examples/it.xsemantics.example.expressions.ui/plugin.xml
+++ b/examples/it.xsemantics.example.expressions.ui/plugin.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <?eclipse version="3.0"?>
 
 <plugin>

--- a/examples/it.xsemantics.example.expressions.ui/pom.xml
+++ b/examples/it.xsemantics.example.expressions.ui/pom.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/examples/it.xsemantics.example.expressions/META-INF/MANIFEST.MF
+++ b/examples/it.xsemantics.example.expressions/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Xsemantics Expressions Example
-Bundle-Vendor: Lorenzo Bettini
+Bundle-Vendor: %providerName
 Bundle-Version: 1.12.1.qualifier
 Bundle-SymbolicName: it.xsemantics.example.expressions;singleton:=true
 Bundle-ActivationPolicy: lazy

--- a/examples/it.xsemantics.example.expressions/about.html
+++ b/examples/it.xsemantics.example.expressions/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>July 11, 2017</p>
+
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/examples/it.xsemantics.example.expressions/old/GenerateXsemanticsArtifacts.mwe2
+++ b/examples/it.xsemantics.example.expressions/old/GenerateXsemanticsArtifacts.mwe2
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ *******************************************************************************/
 module GenerateXsemanticsArtifacts
 
 import org.eclipse.emf.mwe.utils.*

--- a/examples/it.xsemantics.example.expressions/plugin.properties
+++ b/examples/it.xsemantics.example.expressions/plugin.properties
@@ -1,0 +1,3 @@
+
+pluginName = it.xsemantics.example.expressions
+providerName = Eclipse Xsemantics Project

--- a/examples/it.xsemantics.example.expressions/plugin.xml
+++ b/examples/it.xsemantics.example.expressions/plugin.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <?eclipse version="3.0"?>
 
 <plugin>

--- a/examples/it.xsemantics.example.expressions/pom.xml
+++ b/examples/it.xsemantics.example.expressions/pom.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/examples/it.xsemantics.example.expressions/src/it/xsemantics/example/expressions/GenerateExpressions.mwe2
+++ b/examples/it.xsemantics.example.expressions/src/it/xsemantics/example/expressions/GenerateExpressions.mwe2
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ *******************************************************************************/
 module it.xsemantics.example.expressions.GenerateExpressions
 
 import org.eclipse.emf.mwe.utils.*

--- a/examples/it.xsemantics.example.expressions/src/it/xsemantics/example/expressions/typing/expressions-cached.xsemantics
+++ b/examples/it.xsemantics.example.expressions/src/it/xsemantics/example/expressions/typing/expressions-cached.xsemantics
@@ -20,6 +20,17 @@ import it.xsemantics.example.expressions.expressions.Variable
 system it.xsemantics.example.expressions.typing.CachedExpressionsSemantics
 	extends ExtendedExpressionsSemantics
 
+copyright
+"Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API"
+	
+
 judgments {
 	override vartype ||- Variable variable : output Type
 		cached

--- a/examples/it.xsemantics.example.expressions/src/it/xsemantics/example/expressions/typing/expressions-extended.xsemantics
+++ b/examples/it.xsemantics.example.expressions/src/it/xsemantics/example/expressions/typing/expressions-extended.xsemantics
@@ -33,6 +33,17 @@ import it.xsemantics.example.expressions.expressions.Type
 system it.xsemantics.example.expressions.typing.ExtendedExpressionsSemantics
 	extends ExpressionsSemantics
 
+copyright
+"Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API"
+	
+
 judgments {
 	coerce |~ Expression expression |> Type expectedType
 		error "cannot convert " + stringRep(expression) +

--- a/examples/it.xsemantics.example.expressions/src/it/xsemantics/example/expressions/typing/expressions-first.xsemantics
+++ b/examples/it.xsemantics.example.expressions/src/it/xsemantics/example/expressions/typing/expressions-first.xsemantics
@@ -38,6 +38,17 @@ import it.xsemantics.example.expressions.validation.AbstractExpressionsJavaValid
  */
 system it.xsemantics.example.expressions.typing.ExpressionsSemantics
 
+copyright
+"Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API"
+
+
 validatorExtends AbstractExpressionsJavaValidator
 
 judgments {

--- a/examples/it.xsemantics.example.fj.tests/META-INF/MANIFEST.MF
+++ b/examples/it.xsemantics.example.fj.tests/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Xsemantics FJ Example Tests
 Bundle-SymbolicName: it.xsemantics.example.fj.tests;singleton:=true
 Bundle-Version: 1.12.1.qualifier
 Bundle-ClassPath: .
-Bundle-Vendor: Lorenzo Bettini
+Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Export-Package: it.xsemantics.example.fj.tests,

--- a/examples/it.xsemantics.example.fj.tests/about.html
+++ b/examples/it.xsemantics.example.fj.tests/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>July 11, 2017</p>
+
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/examples/it.xsemantics.example.fj.tests/build.properties
+++ b/examples/it.xsemantics.example.fj.tests/build.properties
@@ -1,9 +1,3 @@
-
-# <copyright>
-# </copyright>
-#
-# $Id: build.properties,v 1.1 2009-10-25 16:22:12 bettini Exp $
-
 bin.includes = .,\
                META-INF/,\
                plugin.properties

--- a/examples/it.xsemantics.example.fj.tests/old/CastTest.java
+++ b/examples/it.xsemantics.example.fj.tests/old/CastTest.java
@@ -9,12 +9,6 @@
  *   Lorenzo Bettini - Initial contribution and API
  *******************************************************************************/
 
-/**
- * <copyright>
- * </copyright>
- *
- * $Id: CastTest.java,v 1.1 2009-11-02 11:25:12 bettini Exp $
- */
 package it.xsemantics.example.fj.tests;
 
 import it.xsemantics.example.fj.FJStandaloneSetup;

--- a/examples/it.xsemantics.example.fj.tests/old/ClassTest.java
+++ b/examples/it.xsemantics.example.fj.tests/old/ClassTest.java
@@ -9,12 +9,6 @@
  *   Lorenzo Bettini - Initial contribution and API
  *******************************************************************************/
 
-/**
- * <copyright>
- * </copyright>
- *
- * $Id: ClassTest.java,v 1.1 2009-11-02 11:25:13 bettini Exp $
- */
 package it.xsemantics.example.fj.tests;
 
 import it.xsemantics.example.fj.fj.Class;

--- a/examples/it.xsemantics.example.fj.tests/plugin.properties
+++ b/examples/it.xsemantics.example.fj.tests/plugin.properties
@@ -4,5 +4,5 @@
 #
 # $Id: plugin.properties,v 1.1 2009-10-25 16:22:12 bettini Exp $
 
-pluginName = FJ Tests
-providerName = www.example.org
+pluginName = it.xsemantics.example.fj.tests
+providerName = Eclipse Xsemantics Project

--- a/examples/it.xsemantics.example.fj.tests/plugin.properties
+++ b/examples/it.xsemantics.example.fj.tests/plugin.properties
@@ -1,8 +1,3 @@
 
-# <copyright>
-# </copyright>
-#
-# $Id: plugin.properties,v 1.1 2009-10-25 16:22:12 bettini Exp $
-
 pluginName = it.xsemantics.example.fj.tests
 providerName = Eclipse Xsemantics Project

--- a/examples/it.xsemantics.example.fj.tests/pom.xml
+++ b/examples/it.xsemantics.example.fj.tests/pom.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/examples/it.xsemantics.example.fj.tests/src/it/xsemantics/example/fj/tests/FjExample.java
+++ b/examples/it.xsemantics.example.fj.tests/src/it/xsemantics/example/fj/tests/FjExample.java
@@ -9,12 +9,6 @@
  *   Lorenzo Bettini - Initial contribution and API
  *******************************************************************************/
 
-/**
- * <copyright>
- * </copyright>
- *
- * $Id$
- */
 package it.xsemantics.example.fj.tests;
 
 import java.io.File;

--- a/examples/it.xsemantics.example.fj.tests/src/it/xsemantics/example/fj/tests/FjTests.java
+++ b/examples/it.xsemantics.example.fj.tests/src/it/xsemantics/example/fj/tests/FjTests.java
@@ -9,12 +9,6 @@
  *   Lorenzo Bettini - Initial contribution and API
  *******************************************************************************/
 
-/**
- * <copyright>
- * </copyright>
- *
- * $Id$
- */
 package it.xsemantics.example.fj.tests;
 
 import junit.framework.Test;

--- a/examples/it.xsemantics.example.fj.tests/src/it/xsemantics/example/fj/tests/FormattingTest.java
+++ b/examples/it.xsemantics.example.fj.tests/src/it/xsemantics/example/fj/tests/FormattingTest.java
@@ -9,12 +9,6 @@
  *   Lorenzo Bettini - Initial contribution and API
  *******************************************************************************/
 
-/**
- * <copyright>
- * </copyright>
- *
- * $Id: ProgramTest.java,v 1.1 2009-11-02 11:25:13 bettini Exp $
- */
 package it.xsemantics.example.fj.tests;
 
 import it.xsemantics.example.fj.fj.Class;

--- a/examples/it.xsemantics.example.fj.tests/src/it/xsemantics/example/fj/tests/ProgramTest.java
+++ b/examples/it.xsemantics.example.fj.tests/src/it/xsemantics/example/fj/tests/ProgramTest.java
@@ -9,12 +9,6 @@
  *   Lorenzo Bettini - Initial contribution and API
  *******************************************************************************/
 
-/**
- * <copyright>
- * </copyright>
- *
- * $Id: ProgramTest.java,v 1.1 2009-11-02 11:25:13 bettini Exp $
- */
 package it.xsemantics.example.fj.tests;
 
 import it.xsemantics.example.fj.fj.Class;

--- a/examples/it.xsemantics.example.fj.tests/src/it/xsemantics/example/fj/tests/TestWithLoader.java
+++ b/examples/it.xsemantics.example.fj.tests/src/it/xsemantics/example/fj/tests/TestWithLoader.java
@@ -9,12 +9,6 @@
  *   Lorenzo Bettini - Initial contribution and API
  *******************************************************************************/
 
-/**
- * <copyright>
- * </copyright>
- *
- * $Id: TestWithLoader.java,v 1.1 2009-11-02 11:25:12 bettini Exp $
- */
 package it.xsemantics.example.fj.tests;
 
 import it.xsemantics.example.fj.fj.Program;

--- a/examples/it.xsemantics.example.fj.ui/META-INF/MANIFEST.MF
+++ b/examples/it.xsemantics.example.fj.ui/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Xsemantics FJ Eclipse UI
-Bundle-Vendor: Lorenzo Bettini
+Bundle-Vendor: %providerName
 Bundle-Version: 1.12.1.qualifier
 Bundle-SymbolicName: it.xsemantics.example.fj.ui;singleton:=true
 Bundle-ActivationPolicy: lazy

--- a/examples/it.xsemantics.example.fj.ui/about.html
+++ b/examples/it.xsemantics.example.fj.ui/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>July 11, 2017</p>
+
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/examples/it.xsemantics.example.fj.ui/plugin.properties
+++ b/examples/it.xsemantics.example.fj.ui/plugin.properties
@@ -1,3 +1,3 @@
 
-pluginName = it.xsemantics.dsl
+pluginName = it.xsemantics.example.fj.ui
 providerName = Eclipse Xsemantics Project

--- a/examples/it.xsemantics.example.fj.ui/plugin.xml
+++ b/examples/it.xsemantics.example.fj.ui/plugin.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <?eclipse version="3.0"?>
 
 <plugin>

--- a/examples/it.xsemantics.example.fj.ui/pom.xml
+++ b/examples/it.xsemantics.example.fj.ui/pom.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/examples/it.xsemantics.example.fj.ui/templates/templates.xml
+++ b/examples/it.xsemantics.example.fj.ui/templates/templates.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <templates>
 	<template autoinsert="true" context="it.xsemantics.example.fj.FJ.Class"
 		deleted="false" description="template class definition" enabled="true"

--- a/examples/it.xsemantics.example.fj.ui/templates/templates.xml
+++ b/examples/it.xsemantics.example.fj.ui/templates/templates.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <templates>
 	<template autoinsert="true" context="it.xsemantics.example.fj.FJ.Class"
 		deleted="false" description="template class definition" enabled="true"

--- a/examples/it.xsemantics.example.fj/META-INF/MANIFEST.MF
+++ b/examples/it.xsemantics.example.fj/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Xsemantics FJ Example
-Bundle-Vendor: Lorenzo Bettini
+Bundle-Vendor: %providerName
 Bundle-Version: 1.12.1.qualifier
 Bundle-SymbolicName: it.xsemantics.example.fj;singleton:=true
 Bundle-ActivationPolicy: lazy

--- a/examples/it.xsemantics.example.fj/about.html
+++ b/examples/it.xsemantics.example.fj/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>July 11, 2017</p>
+
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/examples/it.xsemantics.example.fj/old/GenerateXsemanticsArtifacts.mwe2
+++ b/examples/it.xsemantics.example.fj/old/GenerateXsemanticsArtifacts.mwe2
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ *******************************************************************************/
 module GenerateXsemanticsArtifacts
 
 import org.eclipse.emf.mwe.utils.*

--- a/examples/it.xsemantics.example.fj/plugin.properties
+++ b/examples/it.xsemantics.example.fj/plugin.properties
@@ -1,3 +1,3 @@
 
-pluginName = it.xsemantics.dsl
+pluginName = it.xsemantics.example.fj
 providerName = Eclipse Xsemantics Project

--- a/examples/it.xsemantics.example.fj/plugin.xml
+++ b/examples/it.xsemantics.example.fj/plugin.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <?eclipse version="3.0"?>
 
 <plugin>

--- a/examples/it.xsemantics.example.fj/pom.xml
+++ b/examples/it.xsemantics.example.fj/pom.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/examples/it.xsemantics.example.fj/src/it/xsemantics/example/fj/GenerateFJ.mwe2
+++ b/examples/it.xsemantics.example.fj/src/it/xsemantics/example/fj/GenerateFJ.mwe2
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ *******************************************************************************/
 module it.xsemantics.example.fj.FJ
 
 import org.eclipse.emf.mwe.utils.*

--- a/examples/it.xsemantics.example.fj/src/it/xsemantics/example/fj/typing/fj-separated.xsemantics
+++ b/examples/it.xsemantics.example.fj/src/it/xsemantics/example/fj/typing/fj-separated.xsemantics
@@ -33,6 +33,17 @@ import org.eclipse.xtext.EcoreUtil2
  */
 system it.xsemantics.example.fj.typing.FjSepTypeSystem extends FjTypeSystem
 
+copyright
+"Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API"
+
+
 inject FjAuxiliaryFunctions fjAux
 
 judgments {

--- a/examples/it.xsemantics.example.fj/src/it/xsemantics/example/fj/typing/fj.xsemantics
+++ b/examples/it.xsemantics.example.fj/src/it/xsemantics/example/fj/typing/fj.xsemantics
@@ -44,6 +44,17 @@ import org.eclipse.xtext.EcoreUtil2
  */
 system it.xsemantics.example.fj.typing.FjTypeSystem
 
+copyright
+"Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API"
+
+
 inject FjTypeUtils fjTypeUtils
 
 auxiliary {

--- a/examples/it.xsemantics.example.fjcached.tests/META-INF/MANIFEST.MF
+++ b/examples/it.xsemantics.example.fjcached.tests/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: it.xsemantics.example.fjcached.tests
-Bundle-Vendor: Lorenzo Bettini
+Bundle-Vendor: %providerName
 Bundle-Version: 1.12.1.qualifier
 Bundle-SymbolicName: it.xsemantics.example.fjcached.tests; singleton:=true
 Bundle-ActivationPolicy: lazy

--- a/examples/it.xsemantics.example.fjcached.tests/about.html
+++ b/examples/it.xsemantics.example.fjcached.tests/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>July 11, 2017</p>
+
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/examples/it.xsemantics.example.fjcached.tests/plugin.properties
+++ b/examples/it.xsemantics.example.fjcached.tests/plugin.properties
@@ -1,0 +1,3 @@
+
+pluginName = it.xsemantics.example.fjcached.tests
+providerName = Eclipse Xsemantics Project

--- a/examples/it.xsemantics.example.fjcached.tests/pom.xml
+++ b/examples/it.xsemantics.example.fjcached.tests/pom.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/examples/it.xsemantics.example.fjcached.ui/META-INF/MANIFEST.MF
+++ b/examples/it.xsemantics.example.fjcached.ui/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: it.xsemantics.example.fjcached.ui
-Bundle-Vendor: Lorenzo Bettini
+Bundle-Vendor: %providerName
 Bundle-Version: 1.12.1.qualifier
 Bundle-SymbolicName: it.xsemantics.example.fjcached.ui; singleton:=true
 Bundle-ActivationPolicy: lazy

--- a/examples/it.xsemantics.example.fjcached.ui/about.html
+++ b/examples/it.xsemantics.example.fjcached.ui/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>July 11, 2017</p>
+
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/examples/it.xsemantics.example.fjcached.ui/plugin.properties
+++ b/examples/it.xsemantics.example.fjcached.ui/plugin.properties
@@ -1,0 +1,3 @@
+
+pluginName = it.xsemantics.example.fjcached.ui
+providerName = Eclipse Xsemantics Project

--- a/examples/it.xsemantics.example.fjcached.ui/plugin.xml
+++ b/examples/it.xsemantics.example.fjcached.ui/plugin.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <?eclipse version="3.0"?>
 
 <plugin>

--- a/examples/it.xsemantics.example.fjcached.ui/pom.xml
+++ b/examples/it.xsemantics.example.fjcached.ui/pom.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/examples/it.xsemantics.example.fjcached/META-INF/MANIFEST.MF
+++ b/examples/it.xsemantics.example.fjcached/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: it.xsemantics.example.fjcached
-Bundle-Vendor: Lorenzo Bettini
+Bundle-Vendor: %providerName
 Bundle-Version: 1.12.1.qualifier
 Bundle-SymbolicName: it.xsemantics.example.fjcached; singleton:=true
 Bundle-ActivationPolicy: lazy

--- a/examples/it.xsemantics.example.fjcached/about.html
+++ b/examples/it.xsemantics.example.fjcached/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>July 11, 2017</p>
+
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/examples/it.xsemantics.example.fjcached/old/GenerateXsemanticsArtifacts.mwe2
+++ b/examples/it.xsemantics.example.fjcached/old/GenerateXsemanticsArtifacts.mwe2
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ *******************************************************************************/
 module GenerateXsemanticsArtifacts
 
 import org.eclipse.emf.mwe.utils.*

--- a/examples/it.xsemantics.example.fjcached/plugin.properties
+++ b/examples/it.xsemantics.example.fjcached/plugin.properties
@@ -1,0 +1,3 @@
+
+pluginName = it.xsemantics.example.fjcached
+providerName = Eclipse Xsemantics Project

--- a/examples/it.xsemantics.example.fjcached/plugin.xml
+++ b/examples/it.xsemantics.example.fjcached/plugin.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <?eclipse version="3.0"?>
 
 <plugin>

--- a/examples/it.xsemantics.example.fjcached/pom.xml
+++ b/examples/it.xsemantics.example.fjcached/pom.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/examples/it.xsemantics.example.fjcached/src/it/xsemantics/example/fjcached/GenerateFjcached.mwe2
+++ b/examples/it.xsemantics.example.fjcached/src/it/xsemantics/example/fjcached/GenerateFjcached.mwe2
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ *******************************************************************************/
 module it.xsemantics.example.fjcached.GenerateFjcached
 
 import org.eclipse.emf.mwe.utils.*

--- a/examples/it.xsemantics.example.fjcached/src/it/xsemantics/example/fjcached/typing/fj-cached.xsemantics
+++ b/examples/it.xsemantics.example.fjcached/src/it/xsemantics/example/fjcached/typing/fj-cached.xsemantics
@@ -24,6 +24,17 @@ import it.xsemantics.example.fj.fj.BasicType
  */
 system it.xsemantics.example.fjcached.typing.FjCachedTypeSystem extends FjTypeSystem
 
+copyright
+"Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API"
+
+
 auxiliary {
 	override superclasses(Class cl) : List<Class> cached
 	override fields(Class cl) : List<Field> cached

--- a/examples/it.xsemantics.example.lambda.tests/META-INF/MANIFEST.MF
+++ b/examples/it.xsemantics.example.lambda.tests/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Lambda Tests
 Bundle-SymbolicName: it.xsemantics.example.lambda.tests
 Bundle-Version: 1.12.1.qualifier
 Bundle-Activator: it.xsemantics.example.lambda.tests.Activator
-Bundle-Vendor: Lorenzo Bettini
+Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,
  it.xsemantics.example.lambda;bundle-version="1.0.0",
  it.xsemantics.example.lambda.ui;bundle-version="1.0.0",

--- a/examples/it.xsemantics.example.lambda.tests/about.html
+++ b/examples/it.xsemantics.example.lambda.tests/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>July 11, 2017</p>
+
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/examples/it.xsemantics.example.lambda.tests/plugin.properties
+++ b/examples/it.xsemantics.example.lambda.tests/plugin.properties
@@ -1,0 +1,3 @@
+
+pluginName = it.xsemantics.example.lambda.tests
+providerName = Eclipse Xsemantics Project

--- a/examples/it.xsemantics.example.lambda.tests/pom.xml
+++ b/examples/it.xsemantics.example.lambda.tests/pom.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/examples/it.xsemantics.example.lambda.ui/META-INF/MANIFEST.MF
+++ b/examples/it.xsemantics.example.lambda.ui/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Xsemantics Lambda Example UI
-Bundle-Vendor: Lorenzo Bettini
+Bundle-Vendor: %providerName
 Bundle-Version: 1.12.1.qualifier
 Bundle-SymbolicName: it.xsemantics.example.lambda.ui;singleton:=true
 Bundle-ActivationPolicy: lazy

--- a/examples/it.xsemantics.example.lambda.ui/about.html
+++ b/examples/it.xsemantics.example.lambda.ui/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>July 11, 2017</p>
+
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/examples/it.xsemantics.example.lambda.ui/plugin.properties
+++ b/examples/it.xsemantics.example.lambda.ui/plugin.properties
@@ -1,0 +1,3 @@
+
+pluginName = it.xsemantics.example.lambda.ui
+providerName = Eclipse Xsemantics Project

--- a/examples/it.xsemantics.example.lambda.ui/plugin.xml
+++ b/examples/it.xsemantics.example.lambda.ui/plugin.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <?eclipse version="3.0"?>
 
 <plugin>

--- a/examples/it.xsemantics.example.lambda.ui/pom.xml
+++ b/examples/it.xsemantics.example.lambda.ui/pom.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/examples/it.xsemantics.example.lambda/META-INF/MANIFEST.MF
+++ b/examples/it.xsemantics.example.lambda/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Xsemantics Lambda Example
-Bundle-Vendor: Lorenzo Bettini
+Bundle-Vendor: %providerName
 Bundle-Version: 1.12.1.qualifier
 Bundle-SymbolicName: it.xsemantics.example.lambda;singleton:=true
 Bundle-ActivationPolicy: lazy

--- a/examples/it.xsemantics.example.lambda/about.html
+++ b/examples/it.xsemantics.example.lambda/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>July 11, 2017</p>
+
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/examples/it.xsemantics.example.lambda/old/GenerateXsemanticsArtifacts.mwe2
+++ b/examples/it.xsemantics.example.lambda/old/GenerateXsemanticsArtifacts.mwe2
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ *******************************************************************************/
 module GenerateXsemanticsArtifacts
 
 import org.eclipse.emf.mwe.utils.*

--- a/examples/it.xsemantics.example.lambda/plugin.properties
+++ b/examples/it.xsemantics.example.lambda/plugin.properties
@@ -1,3 +1,3 @@
 
-pluginName = it.xsemantics.dsl
+pluginName = it.xsemantics.example.lambda
 providerName = Eclipse Xsemantics Project

--- a/examples/it.xsemantics.example.lambda/plugin.xml
+++ b/examples/it.xsemantics.example.lambda/plugin.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <?eclipse version="3.0"?>
 
 <plugin>

--- a/examples/it.xsemantics.example.lambda/pom.xml
+++ b/examples/it.xsemantics.example.lambda/pom.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/examples/it.xsemantics.example.lambda/src/it/xsemantics/example/lambda/GenerateLambda.mwe2
+++ b/examples/it.xsemantics.example.lambda/src/it/xsemantics/example/lambda/GenerateLambda.mwe2
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ *******************************************************************************/
 module it.xsemantics.example.lambda.Lambda
 
 import org.eclipse.emf.mwe.utils.*

--- a/examples/it.xsemantics.example.lambda/src/it/xsemantics/example/lambda/xsemantics/Lambda.xsemantics
+++ b/examples/it.xsemantics.example.lambda/src/it/xsemantics/example/lambda/xsemantics/Lambda.xsemantics
@@ -29,6 +29,17 @@ import org.eclipse.emf.ecore.util.EcoreUtil
 
 system it.xsemantics.example.lambda.xsemantics.LambdaXsemanticsSystem
 
+copyright
+"Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API"
+
+
 validatorExtends AbstractLambdaJavaValidator
 
 inject LambdaUtils lambdaUtils

--- a/examples/it.xsemantics.ui.examples/META-INF/MANIFEST.MF
+++ b/examples/it.xsemantics.ui.examples/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Xsemantics Examples
 Bundle-SymbolicName: it.xsemantics.ui.examples;singleton:=true
 Bundle-Version: 1.12.1.qualifier
-Bundle-Vendor: Lorenzo Bettini
+Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipse.ui;bundle-version="3.5.0",
  org.eclipse.emf.common.ui;bundle-version="2.7.0",

--- a/examples/it.xsemantics.ui.examples/about.html
+++ b/examples/it.xsemantics.ui.examples/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>July 11, 2017</p>
+
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/examples/it.xsemantics.ui.examples/build.xml
+++ b/examples/it.xsemantics.ui.examples/build.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <!-- ====================================================================== 
      May 25, 2010 10:34:57 AM                                                        
 

--- a/examples/it.xsemantics.ui.examples/plugin.properties
+++ b/examples/it.xsemantics.ui.examples/plugin.properties
@@ -1,3 +1,3 @@
 
-pluginName = it.xsemantics.dsl
+pluginName = it.xsemantics.ui.examples
 providerName = Eclipse Xsemantics Project

--- a/examples/it.xsemantics.ui.examples/plugin.xml
+++ b/examples/it.xsemantics.ui.examples/plugin.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <?eclipse version="3.4"?>
 <plugin>
 	<extension point="org.eclipse.ui.newWizards">

--- a/examples/it.xsemantics.ui.examples/pom.xml
+++ b/examples/it.xsemantics.ui.examples/pom.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/features/it.xsemantics.doc.feature/feature.properties
+++ b/features/it.xsemantics.doc.feature/feature.properties
@@ -1,3 +1,3 @@
 
-pluginName = it.xsemantics.dsl
+featureName = it.xsemantics.doc.feature
 providerName = Eclipse Xsemantics Project

--- a/features/it.xsemantics.doc.feature/feature.xml
+++ b/features/it.xsemantics.doc.feature/feature.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <feature
       id="it.xsemantics.doc.feature"
       label="Xsemantics Documentation Feature"

--- a/features/it.xsemantics.doc.feature/feature.xml
+++ b/features/it.xsemantics.doc.feature/feature.xml
@@ -13,7 +13,9 @@ Contributors:
       id="it.xsemantics.doc.feature"
       label="Xsemantics Documentation Feature"
       version="1.12.1.qualifier"
-      provider-name="Lorenzo Bettini">
+      provider-name="%providerName"
+      license-feature="org.eclipse.license"
+      license-feature-version="1.0.1.v20140414-1359">
 
    <description url="http://xsemantics.sourceforge.net">
       Xsemantics is a DSL (implemented in Xtext itself) for writing
@@ -24,98 +26,19 @@ for scoping and validation (it can also generate a validator
 in Java).
    </description>
 
-   <copyright url="http://www.lorenzobettini.it">
-      2012, Lorenzo Bettini
+   <copyright>
+      Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
    </copyright>
 
-   <license url="http://www.eclipse.org/org/documents/epl-v10.html">
-      Eclipse Public License - v 1.0
-
-THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC LICENSE (&quot;AGREEMENT&quot;). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT&apos;S ACCEPTANCE OF THIS AGREEMENT.
-
-1. DEFINITIONS
-
-&quot;Contribution&quot; means:
-
-a) in the case of the initial Contributor, the initial code and documentation distributed under this Agreement, and
-
-b) in the case of each subsequent Contributor:
-
-i) changes to the Program, and
-
-ii) additions to the Program;
-
-where such changes and/or additions to the Program originate from and are distributed by that particular Contributor. A Contribution &apos;originates&apos; from a Contributor if it was added to the Program by such Contributor itself or anyone acting on such Contributor&apos;s behalf. Contributions do not include additions to the Program which: (i) are separate modules of software distributed in conjunction with the Program under their own license agreement, and (ii) are not derivative works of the Program.
-
-&quot;Contributor&quot; means any person or entity that distributes the Program.
-
-&quot;Licensed Patents&quot; mean patent claims licensable by a Contributor which are necessarily infringed by the use or sale of its Contribution alone or when combined with the Program.
-
-&quot;Program&quot; means the Contributions distributed in accordance with this Agreement.
-
-&quot;Recipient&quot; means anyone who receives the Program under this Agreement, including all Contributors.
-
-2. GRANT OF RIGHTS
-
-a) Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, distribute and sublicense the Contribution of such Contributor, if any, and such derivative works, in source code and object code form.
-
-b) Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free patent license under Licensed Patents to make, use, sell, offer to sell, import and otherwise transfer the Contribution of such Contributor, if any, in source code and object code form. This patent license shall apply to the combination of the Contribution and the Program if, at the time the Contribution is added by the Contributor, such addition of the Contribution causes such combination to be covered by the Licensed Patents. The patent license shall not apply to any other combinations which include the Contribution. No hardware per se is licensed hereunder.
-
-c) Recipient understands that although each Contributor grants the licenses to its Contributions set forth herein, no assurances are provided by any Contributor that the Program does not infringe the patent or other intellectual property rights of any other entity. Each Contributor disclaims any liability to Recipient for claims brought by any other entity based on infringement of intellectual property rights or otherwise. As a condition to exercising the rights and licenses granted hereunder, each Recipient hereby assumes sole responsibility to secure any other intellectual property rights needed, if any. For example, if a third party patent license is required to allow Recipient to distribute the Program, it is Recipient&apos;s responsibility to acquire that license before distributing the Program.
-
-d) Each Contributor represents that to its knowledge it has sufficient copyright rights in its Contribution, if any, to grant the copyright license set forth in this Agreement.
-
-3. REQUIREMENTS
-
-A Contributor may choose to distribute the Program in object code form under its own license agreement, provided that:
-
-a) it complies with the terms and conditions of this Agreement; and
-
-b) its license agreement:
-
-i) effectively disclaims on behalf of all Contributors all warranties and conditions, express and implied, including warranties or conditions of title and non-infringement, and implied warranties or conditions of merchantability and fitness for a particular purpose;
-
-ii) effectively excludes on behalf of all Contributors all liability for damages, including direct, indirect, special, incidental and consequential damages, such as lost profits;
-
-iii) states that any provisions which differ from this Agreement are offered by that Contributor alone and not by any other party; and
-
-iv) states that source code for the Program is available from such Contributor, and informs licensees how to obtain it in a reasonable manner on or through a medium customarily used for software exchange.
-
-When the Program is made available in source code form:
-
-a) it must be made available under this Agreement; and
-
-b) a copy of this Agreement must be included with each copy of the Program.
-
-Contributors may not remove or alter any copyright notices contained within the Program.
-
-Each Contributor must identify itself as the originator of its Contribution, if any, in a manner that reasonably allows subsequent Recipients to identify the originator of the Contribution.
-
-4. COMMERCIAL DISTRIBUTION
-
-Commercial distributors of software may accept certain responsibilities with respect to end users, business partners and the like. While this license is intended to facilitate the commercial use of the Program, the Contributor who includes the Program in a commercial product offering should do so in a manner which does not create potential liability for other Contributors. Therefore, if a Contributor includes the Program in a commercial product offering, such Contributor (&quot;Commercial Contributor&quot;) hereby agrees to defend and indemnify every other Contributor (&quot;Indemnified Contributor&quot;) against any losses, damages and costs (collectively &quot;Losses&quot;) arising from claims, lawsuits and other legal actions brought by a third party against the Indemnified Contributor to the extent caused by the acts or omissions of such Commercial Contributor in connection with its distribution of the Program in a commercial product offering. The obligations in this section do not apply to any claims or Losses relating to any actual or alleged intellectual property infringement. In order to qualify, an Indemnified Contributor must: a) promptly notify the Commercial Contributor in writing of such claim, and b) allow the Commercial Contributor to control, and cooperate with the Commercial Contributor in, the defense and any related settlement negotiations. The Indemnified Contributor may participate in any such claim at its own expense.
-
-For example, a Contributor might include the Program in a commercial product offering, Product X. That Contributor is then a Commercial Contributor. If that Commercial Contributor then makes performance claims, or offers warranties related to Product X, those performance claims and warranties are such Commercial Contributor&apos;s responsibility alone. Under this section, the Commercial Contributor would have to defend claims against the other Contributors related to those performance claims and warranties, and if a court requires any other Contributor to pay any damages as a result, the Commercial Contributor must pay those damages.
-
-5. NO WARRANTY
-
-EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely responsible for determining the appropriateness of using and distributing the Program and assumes all risks associated with its exercise of rights under this Agreement , including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and unavailability or interruption of operations.
-
-6. DISCLAIMER OF LIABILITY
-
-EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
-
-7. GENERAL
-
-If any provision of this Agreement is invalid or unenforceable under applicable law, it shall not affect the validity or enforceability of the remainder of the terms of this Agreement, and without further action by the parties hereto, such provision shall be reformed to the minimum extent necessary to make such provision valid and enforceable.
-
-If Recipient institutes patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Program itself (excluding combinations of the Program with other software or hardware) infringes such Recipient&apos;s patent(s), then such Recipient&apos;s rights granted under Section 2(b) shall terminate as of the date such litigation is filed.
-
-All Recipient&apos;s rights under this Agreement shall terminate if it fails to comply with any of the material terms or conditions of this Agreement and does not cure such failure in a reasonable period of time after becoming aware of such noncompliance. If all Recipient&apos;s rights under this Agreement terminate, Recipient agrees to cease use and distribution of the Program as soon as reasonably practicable. However, Recipient&apos;s obligations under this Agreement and any licenses granted by Recipient relating to the Program shall continue and survive.
-
-Everyone is permitted to copy and distribute copies of this Agreement, but in order to avoid inconsistency the Agreement is copyrighted and may only be modified in the following manner. The Agreement Steward reserves the right to publish new versions (including revisions) of this Agreement from time to time. No one other than the Agreement Steward has the right to modify this Agreement. The Eclipse Foundation is the initial Agreement Steward. The Eclipse Foundation may assign the responsibility to serve as the Agreement Steward to a suitable separate entity. Each new version of the Agreement will be given a distinguishing version number. The Program (including Contributions) may always be distributed subject to the version of the Agreement under which it was received. In addition, after a new version of the Agreement is published, Contributor may elect to distribute the Program (including its Contributions) under the new version. Except as expressly stated in Sections 2(a) and 2(b) above, Recipient receives no rights or licenses to the intellectual property of any Contributor under this Agreement, whether expressly, by implication, estoppel or otherwise. All rights in the Program not expressly granted under this Agreement are reserved.
-
-This Agreement is governed by the laws of the State of New York and the intellectual property laws of the United States of America. No party to this Agreement will bring a legal action under this Agreement more than one year after the cause of action arose. Each party waives its rights to a jury trial in any resulting litigation.
+   <license url="%licenseURL">
+      %license
    </license>
 
    <plugin

--- a/features/it.xsemantics.doc.feature/pom.xml
+++ b/features/it.xsemantics.doc.feature/pom.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/features/it.xsemantics.dsl.ui.tests.feature/feature.properties
+++ b/features/it.xsemantics.dsl.ui.tests.feature/feature.properties
@@ -1,0 +1,3 @@
+
+featureName = it.xsemantics.dsl.ui.tests.feature
+providerName = Eclipse Xsemantics Project

--- a/features/it.xsemantics.dsl.ui.tests.feature/feature.xml
+++ b/features/it.xsemantics.dsl.ui.tests.feature/feature.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <feature
       id="it.xsemantics.dsl.ui.tests.feature"
       label="Xsemantics Feature For Dsl UI Testing"

--- a/features/it.xsemantics.dsl.ui.tests.feature/feature.xml
+++ b/features/it.xsemantics.dsl.ui.tests.feature/feature.xml
@@ -13,18 +13,27 @@ Contributors:
       id="it.xsemantics.dsl.ui.tests.feature"
       label="Xsemantics Feature For Dsl UI Testing"
       version="1.12.1.qualifier"
-      provider-name="Lorenzo Bettini">
+      provider-name="%providerName"
+      license-feature="org.eclipse.license"
+      license-feature-version="1.0.1.v20140414-1359">
 
    <description url="http://www.example.com/description">
       [Enter Feature Description here.]
    </description>
 
-   <copyright url="http://www.example.com/copyright">
-      [Enter Copyright Description here.]
+   <copyright>
+      Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
    </copyright>
 
-   <license url="http://www.example.com/license">
-      [Enter License Description here.]
+   <license url="%licenseURL">
+      %license
    </license>
 
    <includes

--- a/features/it.xsemantics.examples.feature/feature.properties
+++ b/features/it.xsemantics.examples.feature/feature.properties
@@ -1,0 +1,3 @@
+
+featureName = it.xsemantics.examples.feature
+providerName = Eclipse Xsemantics Project

--- a/features/it.xsemantics.examples.feature/feature.xml
+++ b/features/it.xsemantics.examples.feature/feature.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <feature
       id="it.xsemantics.examples.feature"
       label="Xsemantics Examples"

--- a/features/it.xsemantics.examples.feature/feature.xml
+++ b/features/it.xsemantics.examples.feature/feature.xml
@@ -13,7 +13,9 @@ Contributors:
       id="it.xsemantics.examples.feature"
       label="Xsemantics Examples"
       version="1.12.1.qualifier"
-      provider-name="Lorenzo Bettini">
+      provider-name="%providerName"
+      license-feature="org.eclipse.license"
+      license-feature-version="1.0.1.v20140414-1359">
 
    <description url="http://xsemantics.sourceforge.net">
       This feature provides wizards to import in your workspace some examples of languages which use
@@ -27,98 +29,19 @@ for scoping and validation (it can also generate a validator
 in Java).
    </description>
 
-   <copyright url="http://www.lorenzobettini.it">
-      2012, Lorenzo Bettini
+   <copyright>
+      Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
    </copyright>
 
-   <license url="http://www.eclipse.org/org/documents/epl-v10.html">
-      Eclipse Public License - v 1.0
-
-THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC LICENSE (&quot;AGREEMENT&quot;). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT&apos;S ACCEPTANCE OF THIS AGREEMENT.
-
-1. DEFINITIONS
-
-&quot;Contribution&quot; means:
-
-a) in the case of the initial Contributor, the initial code and documentation distributed under this Agreement, and
-
-b) in the case of each subsequent Contributor:
-
-i) changes to the Program, and
-
-ii) additions to the Program;
-
-where such changes and/or additions to the Program originate from and are distributed by that particular Contributor. A Contribution &apos;originates&apos; from a Contributor if it was added to the Program by such Contributor itself or anyone acting on such Contributor&apos;s behalf. Contributions do not include additions to the Program which: (i) are separate modules of software distributed in conjunction with the Program under their own license agreement, and (ii) are not derivative works of the Program.
-
-&quot;Contributor&quot; means any person or entity that distributes the Program.
-
-&quot;Licensed Patents&quot; mean patent claims licensable by a Contributor which are necessarily infringed by the use or sale of its Contribution alone or when combined with the Program.
-
-&quot;Program&quot; means the Contributions distributed in accordance with this Agreement.
-
-&quot;Recipient&quot; means anyone who receives the Program under this Agreement, including all Contributors.
-
-2. GRANT OF RIGHTS
-
-a) Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, distribute and sublicense the Contribution of such Contributor, if any, and such derivative works, in source code and object code form.
-
-b) Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free patent license under Licensed Patents to make, use, sell, offer to sell, import and otherwise transfer the Contribution of such Contributor, if any, in source code and object code form. This patent license shall apply to the combination of the Contribution and the Program if, at the time the Contribution is added by the Contributor, such addition of the Contribution causes such combination to be covered by the Licensed Patents. The patent license shall not apply to any other combinations which include the Contribution. No hardware per se is licensed hereunder.
-
-c) Recipient understands that although each Contributor grants the licenses to its Contributions set forth herein, no assurances are provided by any Contributor that the Program does not infringe the patent or other intellectual property rights of any other entity. Each Contributor disclaims any liability to Recipient for claims brought by any other entity based on infringement of intellectual property rights or otherwise. As a condition to exercising the rights and licenses granted hereunder, each Recipient hereby assumes sole responsibility to secure any other intellectual property rights needed, if any. For example, if a third party patent license is required to allow Recipient to distribute the Program, it is Recipient&apos;s responsibility to acquire that license before distributing the Program.
-
-d) Each Contributor represents that to its knowledge it has sufficient copyright rights in its Contribution, if any, to grant the copyright license set forth in this Agreement.
-
-3. REQUIREMENTS
-
-A Contributor may choose to distribute the Program in object code form under its own license agreement, provided that:
-
-a) it complies with the terms and conditions of this Agreement; and
-
-b) its license agreement:
-
-i) effectively disclaims on behalf of all Contributors all warranties and conditions, express and implied, including warranties or conditions of title and non-infringement, and implied warranties or conditions of merchantability and fitness for a particular purpose;
-
-ii) effectively excludes on behalf of all Contributors all liability for damages, including direct, indirect, special, incidental and consequential damages, such as lost profits;
-
-iii) states that any provisions which differ from this Agreement are offered by that Contributor alone and not by any other party; and
-
-iv) states that source code for the Program is available from such Contributor, and informs licensees how to obtain it in a reasonable manner on or through a medium customarily used for software exchange.
-
-When the Program is made available in source code form:
-
-a) it must be made available under this Agreement; and
-
-b) a copy of this Agreement must be included with each copy of the Program.
-
-Contributors may not remove or alter any copyright notices contained within the Program.
-
-Each Contributor must identify itself as the originator of its Contribution, if any, in a manner that reasonably allows subsequent Recipients to identify the originator of the Contribution.
-
-4. COMMERCIAL DISTRIBUTION
-
-Commercial distributors of software may accept certain responsibilities with respect to end users, business partners and the like. While this license is intended to facilitate the commercial use of the Program, the Contributor who includes the Program in a commercial product offering should do so in a manner which does not create potential liability for other Contributors. Therefore, if a Contributor includes the Program in a commercial product offering, such Contributor (&quot;Commercial Contributor&quot;) hereby agrees to defend and indemnify every other Contributor (&quot;Indemnified Contributor&quot;) against any losses, damages and costs (collectively &quot;Losses&quot;) arising from claims, lawsuits and other legal actions brought by a third party against the Indemnified Contributor to the extent caused by the acts or omissions of such Commercial Contributor in connection with its distribution of the Program in a commercial product offering. The obligations in this section do not apply to any claims or Losses relating to any actual or alleged intellectual property infringement. In order to qualify, an Indemnified Contributor must: a) promptly notify the Commercial Contributor in writing of such claim, and b) allow the Commercial Contributor to control, and cooperate with the Commercial Contributor in, the defense and any related settlement negotiations. The Indemnified Contributor may participate in any such claim at its own expense.
-
-For example, a Contributor might include the Program in a commercial product offering, Product X. That Contributor is then a Commercial Contributor. If that Commercial Contributor then makes performance claims, or offers warranties related to Product X, those performance claims and warranties are such Commercial Contributor&apos;s responsibility alone. Under this section, the Commercial Contributor would have to defend claims against the other Contributors related to those performance claims and warranties, and if a court requires any other Contributor to pay any damages as a result, the Commercial Contributor must pay those damages.
-
-5. NO WARRANTY
-
-EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely responsible for determining the appropriateness of using and distributing the Program and assumes all risks associated with its exercise of rights under this Agreement , including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and unavailability or interruption of operations.
-
-6. DISCLAIMER OF LIABILITY
-
-EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
-
-7. GENERAL
-
-If any provision of this Agreement is invalid or unenforceable under applicable law, it shall not affect the validity or enforceability of the remainder of the terms of this Agreement, and without further action by the parties hereto, such provision shall be reformed to the minimum extent necessary to make such provision valid and enforceable.
-
-If Recipient institutes patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Program itself (excluding combinations of the Program with other software or hardware) infringes such Recipient&apos;s patent(s), then such Recipient&apos;s rights granted under Section 2(b) shall terminate as of the date such litigation is filed.
-
-All Recipient&apos;s rights under this Agreement shall terminate if it fails to comply with any of the material terms or conditions of this Agreement and does not cure such failure in a reasonable period of time after becoming aware of such noncompliance. If all Recipient&apos;s rights under this Agreement terminate, Recipient agrees to cease use and distribution of the Program as soon as reasonably practicable. However, Recipient&apos;s obligations under this Agreement and any licenses granted by Recipient relating to the Program shall continue and survive.
-
-Everyone is permitted to copy and distribute copies of this Agreement, but in order to avoid inconsistency the Agreement is copyrighted and may only be modified in the following manner. The Agreement Steward reserves the right to publish new versions (including revisions) of this Agreement from time to time. No one other than the Agreement Steward has the right to modify this Agreement. The Eclipse Foundation is the initial Agreement Steward. The Eclipse Foundation may assign the responsibility to serve as the Agreement Steward to a suitable separate entity. Each new version of the Agreement will be given a distinguishing version number. The Program (including Contributions) may always be distributed subject to the version of the Agreement under which it was received. In addition, after a new version of the Agreement is published, Contributor may elect to distribute the Program (including its Contributions) under the new version. Except as expressly stated in Sections 2(a) and 2(b) above, Recipient receives no rights or licenses to the intellectual property of any Contributor under this Agreement, whether expressly, by implication, estoppel or otherwise. All rights in the Program not expressly granted under this Agreement are reserved.
-
-This Agreement is governed by the laws of the State of New York and the intellectual property laws of the United States of America. No party to this Agreement will bring a legal action under this Agreement more than one year after the cause of action arose. Each party waives its rights to a jury trial in any resulting litigation.
+   <license url="%licenseURL">
+      %license
    </license>
 
    <plugin

--- a/features/it.xsemantics.examples.feature/pom.xml
+++ b/features/it.xsemantics.examples.feature/pom.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/features/it.xsemantics.feature/feature.properties
+++ b/features/it.xsemantics.feature/feature.properties
@@ -1,3 +1,3 @@
 
-pluginName = it.xsemantics.dsl
+featureName = it.xsemantics.feature
 providerName = Eclipse Xsemantics Project

--- a/features/it.xsemantics.feature/feature.xml
+++ b/features/it.xsemantics.feature/feature.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <feature
       id="it.xsemantics.feature"
       label="Xsemantics UI"

--- a/features/it.xsemantics.feature/feature.xml
+++ b/features/it.xsemantics.feature/feature.xml
@@ -13,7 +13,9 @@ Contributors:
       id="it.xsemantics.feature"
       label="Xsemantics UI"
       version="1.12.1.qualifier"
-      provider-name="Lorenzo Bettini">
+      provider-name="%providerName"
+      license-feature="org.eclipse.license"
+      license-feature-version="1.0.1.v20140414-1359">
 
    <description url="http://xsemantics.sourceforge.net">
       Xsemantics is a DSL (implemented in Xtext itself) for writing
@@ -24,98 +26,19 @@ for scoping and validation (it can also generate a validator
 in Java).
    </description>
 
-   <copyright url="http://www.lorenzobettini.it">
-      2012, Lorenzo Bettini
+   <copyright>
+      Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
    </copyright>
 
-   <license url="http://www.eclipse.org/org/documents/epl-v10.html">
-      Eclipse Public License - v 1.0
-
-THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC LICENSE (&quot;AGREEMENT&quot;). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT&apos;S ACCEPTANCE OF THIS AGREEMENT.
-
-1. DEFINITIONS
-
-&quot;Contribution&quot; means:
-
-a) in the case of the initial Contributor, the initial code and documentation distributed under this Agreement, and
-
-b) in the case of each subsequent Contributor:
-
-i) changes to the Program, and
-
-ii) additions to the Program;
-
-where such changes and/or additions to the Program originate from and are distributed by that particular Contributor. A Contribution &apos;originates&apos; from a Contributor if it was added to the Program by such Contributor itself or anyone acting on such Contributor&apos;s behalf. Contributions do not include additions to the Program which: (i) are separate modules of software distributed in conjunction with the Program under their own license agreement, and (ii) are not derivative works of the Program.
-
-&quot;Contributor&quot; means any person or entity that distributes the Program.
-
-&quot;Licensed Patents&quot; mean patent claims licensable by a Contributor which are necessarily infringed by the use or sale of its Contribution alone or when combined with the Program.
-
-&quot;Program&quot; means the Contributions distributed in accordance with this Agreement.
-
-&quot;Recipient&quot; means anyone who receives the Program under this Agreement, including all Contributors.
-
-2. GRANT OF RIGHTS
-
-a) Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, distribute and sublicense the Contribution of such Contributor, if any, and such derivative works, in source code and object code form.
-
-b) Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free patent license under Licensed Patents to make, use, sell, offer to sell, import and otherwise transfer the Contribution of such Contributor, if any, in source code and object code form. This patent license shall apply to the combination of the Contribution and the Program if, at the time the Contribution is added by the Contributor, such addition of the Contribution causes such combination to be covered by the Licensed Patents. The patent license shall not apply to any other combinations which include the Contribution. No hardware per se is licensed hereunder.
-
-c) Recipient understands that although each Contributor grants the licenses to its Contributions set forth herein, no assurances are provided by any Contributor that the Program does not infringe the patent or other intellectual property rights of any other entity. Each Contributor disclaims any liability to Recipient for claims brought by any other entity based on infringement of intellectual property rights or otherwise. As a condition to exercising the rights and licenses granted hereunder, each Recipient hereby assumes sole responsibility to secure any other intellectual property rights needed, if any. For example, if a third party patent license is required to allow Recipient to distribute the Program, it is Recipient&apos;s responsibility to acquire that license before distributing the Program.
-
-d) Each Contributor represents that to its knowledge it has sufficient copyright rights in its Contribution, if any, to grant the copyright license set forth in this Agreement.
-
-3. REQUIREMENTS
-
-A Contributor may choose to distribute the Program in object code form under its own license agreement, provided that:
-
-a) it complies with the terms and conditions of this Agreement; and
-
-b) its license agreement:
-
-i) effectively disclaims on behalf of all Contributors all warranties and conditions, express and implied, including warranties or conditions of title and non-infringement, and implied warranties or conditions of merchantability and fitness for a particular purpose;
-
-ii) effectively excludes on behalf of all Contributors all liability for damages, including direct, indirect, special, incidental and consequential damages, such as lost profits;
-
-iii) states that any provisions which differ from this Agreement are offered by that Contributor alone and not by any other party; and
-
-iv) states that source code for the Program is available from such Contributor, and informs licensees how to obtain it in a reasonable manner on or through a medium customarily used for software exchange.
-
-When the Program is made available in source code form:
-
-a) it must be made available under this Agreement; and
-
-b) a copy of this Agreement must be included with each copy of the Program.
-
-Contributors may not remove or alter any copyright notices contained within the Program.
-
-Each Contributor must identify itself as the originator of its Contribution, if any, in a manner that reasonably allows subsequent Recipients to identify the originator of the Contribution.
-
-4. COMMERCIAL DISTRIBUTION
-
-Commercial distributors of software may accept certain responsibilities with respect to end users, business partners and the like. While this license is intended to facilitate the commercial use of the Program, the Contributor who includes the Program in a commercial product offering should do so in a manner which does not create potential liability for other Contributors. Therefore, if a Contributor includes the Program in a commercial product offering, such Contributor (&quot;Commercial Contributor&quot;) hereby agrees to defend and indemnify every other Contributor (&quot;Indemnified Contributor&quot;) against any losses, damages and costs (collectively &quot;Losses&quot;) arising from claims, lawsuits and other legal actions brought by a third party against the Indemnified Contributor to the extent caused by the acts or omissions of such Commercial Contributor in connection with its distribution of the Program in a commercial product offering. The obligations in this section do not apply to any claims or Losses relating to any actual or alleged intellectual property infringement. In order to qualify, an Indemnified Contributor must: a) promptly notify the Commercial Contributor in writing of such claim, and b) allow the Commercial Contributor to control, and cooperate with the Commercial Contributor in, the defense and any related settlement negotiations. The Indemnified Contributor may participate in any such claim at its own expense.
-
-For example, a Contributor might include the Program in a commercial product offering, Product X. That Contributor is then a Commercial Contributor. If that Commercial Contributor then makes performance claims, or offers warranties related to Product X, those performance claims and warranties are such Commercial Contributor&apos;s responsibility alone. Under this section, the Commercial Contributor would have to defend claims against the other Contributors related to those performance claims and warranties, and if a court requires any other Contributor to pay any damages as a result, the Commercial Contributor must pay those damages.
-
-5. NO WARRANTY
-
-EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely responsible for determining the appropriateness of using and distributing the Program and assumes all risks associated with its exercise of rights under this Agreement , including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and unavailability or interruption of operations.
-
-6. DISCLAIMER OF LIABILITY
-
-EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
-
-7. GENERAL
-
-If any provision of this Agreement is invalid or unenforceable under applicable law, it shall not affect the validity or enforceability of the remainder of the terms of this Agreement, and without further action by the parties hereto, such provision shall be reformed to the minimum extent necessary to make such provision valid and enforceable.
-
-If Recipient institutes patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Program itself (excluding combinations of the Program with other software or hardware) infringes such Recipient&apos;s patent(s), then such Recipient&apos;s rights granted under Section 2(b) shall terminate as of the date such litigation is filed.
-
-All Recipient&apos;s rights under this Agreement shall terminate if it fails to comply with any of the material terms or conditions of this Agreement and does not cure such failure in a reasonable period of time after becoming aware of such noncompliance. If all Recipient&apos;s rights under this Agreement terminate, Recipient agrees to cease use and distribution of the Program as soon as reasonably practicable. However, Recipient&apos;s obligations under this Agreement and any licenses granted by Recipient relating to the Program shall continue and survive.
-
-Everyone is permitted to copy and distribute copies of this Agreement, but in order to avoid inconsistency the Agreement is copyrighted and may only be modified in the following manner. The Agreement Steward reserves the right to publish new versions (including revisions) of this Agreement from time to time. No one other than the Agreement Steward has the right to modify this Agreement. The Eclipse Foundation is the initial Agreement Steward. The Eclipse Foundation may assign the responsibility to serve as the Agreement Steward to a suitable separate entity. Each new version of the Agreement will be given a distinguishing version number. The Program (including Contributions) may always be distributed subject to the version of the Agreement under which it was received. In addition, after a new version of the Agreement is published, Contributor may elect to distribute the Program (including its Contributions) under the new version. Except as expressly stated in Sections 2(a) and 2(b) above, Recipient receives no rights or licenses to the intellectual property of any Contributor under this Agreement, whether expressly, by implication, estoppel or otherwise. All rights in the Program not expressly granted under this Agreement are reserved.
-
-This Agreement is governed by the laws of the State of New York and the intellectual property laws of the United States of America. No party to this Agreement will bring a legal action under this Agreement more than one year after the cause of action arose. Each party waives its rights to a jury trial in any resulting litigation.
+   <license url="%licenseURL">
+      %license
    </license>
 
    <includes

--- a/features/it.xsemantics.feature/pom.xml
+++ b/features/it.xsemantics.feature/pom.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/features/it.xsemantics.implemented.examples.feature/feature.properties
+++ b/features/it.xsemantics.implemented.examples.feature/feature.properties
@@ -1,0 +1,3 @@
+
+featureName = it.xsemantics.implemented.examples.feature
+providerName = Eclipse Xsemantics Project

--- a/features/it.xsemantics.implemented.examples.feature/feature.xml
+++ b/features/it.xsemantics.implemented.examples.feature/feature.xml
@@ -13,7 +13,9 @@ Contributors:
       id="it.xsemantics.implemented.examples.feature"
       label="Xsemantics Implemented Examples"
       version="1.12.1.qualifier"
-      provider-name="Lorenzo Bettini">
+      provider-name="%providerName"
+      license-feature="org.eclipse.license"
+      license-feature-version="1.0.1.v20140414-1359">
 
    <description url="http://xsemantics.sourceforge.net">
       This feature contains the implementation of some examples of languages which use
@@ -29,98 +31,19 @@ for scoping and validation (it can also generate a validator
 in Java).
    </description>
 
-   <copyright url="http://www.lorenzobettini.it">
-      2012, Lorenzo Bettini
+   <copyright>
+      Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
    </copyright>
 
-   <license url="http://www.eclipse.org/org/documents/epl-v10.html">
-      Eclipse Public License - v 1.0
-
-THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC LICENSE (&quot;AGREEMENT&quot;). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT&apos;S ACCEPTANCE OF THIS AGREEMENT.
-
-1. DEFINITIONS
-
-&quot;Contribution&quot; means:
-
-a) in the case of the initial Contributor, the initial code and documentation distributed under this Agreement, and
-
-b) in the case of each subsequent Contributor:
-
-i) changes to the Program, and
-
-ii) additions to the Program;
-
-where such changes and/or additions to the Program originate from and are distributed by that particular Contributor. A Contribution &apos;originates&apos; from a Contributor if it was added to the Program by such Contributor itself or anyone acting on such Contributor&apos;s behalf. Contributions do not include additions to the Program which: (i) are separate modules of software distributed in conjunction with the Program under their own license agreement, and (ii) are not derivative works of the Program.
-
-&quot;Contributor&quot; means any person or entity that distributes the Program.
-
-&quot;Licensed Patents&quot; mean patent claims licensable by a Contributor which are necessarily infringed by the use or sale of its Contribution alone or when combined with the Program.
-
-&quot;Program&quot; means the Contributions distributed in accordance with this Agreement.
-
-&quot;Recipient&quot; means anyone who receives the Program under this Agreement, including all Contributors.
-
-2. GRANT OF RIGHTS
-
-a) Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, distribute and sublicense the Contribution of such Contributor, if any, and such derivative works, in source code and object code form.
-
-b) Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free patent license under Licensed Patents to make, use, sell, offer to sell, import and otherwise transfer the Contribution of such Contributor, if any, in source code and object code form. This patent license shall apply to the combination of the Contribution and the Program if, at the time the Contribution is added by the Contributor, such addition of the Contribution causes such combination to be covered by the Licensed Patents. The patent license shall not apply to any other combinations which include the Contribution. No hardware per se is licensed hereunder.
-
-c) Recipient understands that although each Contributor grants the licenses to its Contributions set forth herein, no assurances are provided by any Contributor that the Program does not infringe the patent or other intellectual property rights of any other entity. Each Contributor disclaims any liability to Recipient for claims brought by any other entity based on infringement of intellectual property rights or otherwise. As a condition to exercising the rights and licenses granted hereunder, each Recipient hereby assumes sole responsibility to secure any other intellectual property rights needed, if any. For example, if a third party patent license is required to allow Recipient to distribute the Program, it is Recipient&apos;s responsibility to acquire that license before distributing the Program.
-
-d) Each Contributor represents that to its knowledge it has sufficient copyright rights in its Contribution, if any, to grant the copyright license set forth in this Agreement.
-
-3. REQUIREMENTS
-
-A Contributor may choose to distribute the Program in object code form under its own license agreement, provided that:
-
-a) it complies with the terms and conditions of this Agreement; and
-
-b) its license agreement:
-
-i) effectively disclaims on behalf of all Contributors all warranties and conditions, express and implied, including warranties or conditions of title and non-infringement, and implied warranties or conditions of merchantability and fitness for a particular purpose;
-
-ii) effectively excludes on behalf of all Contributors all liability for damages, including direct, indirect, special, incidental and consequential damages, such as lost profits;
-
-iii) states that any provisions which differ from this Agreement are offered by that Contributor alone and not by any other party; and
-
-iv) states that source code for the Program is available from such Contributor, and informs licensees how to obtain it in a reasonable manner on or through a medium customarily used for software exchange.
-
-When the Program is made available in source code form:
-
-a) it must be made available under this Agreement; and
-
-b) a copy of this Agreement must be included with each copy of the Program.
-
-Contributors may not remove or alter any copyright notices contained within the Program.
-
-Each Contributor must identify itself as the originator of its Contribution, if any, in a manner that reasonably allows subsequent Recipients to identify the originator of the Contribution.
-
-4. COMMERCIAL DISTRIBUTION
-
-Commercial distributors of software may accept certain responsibilities with respect to end users, business partners and the like. While this license is intended to facilitate the commercial use of the Program, the Contributor who includes the Program in a commercial product offering should do so in a manner which does not create potential liability for other Contributors. Therefore, if a Contributor includes the Program in a commercial product offering, such Contributor (&quot;Commercial Contributor&quot;) hereby agrees to defend and indemnify every other Contributor (&quot;Indemnified Contributor&quot;) against any losses, damages and costs (collectively &quot;Losses&quot;) arising from claims, lawsuits and other legal actions brought by a third party against the Indemnified Contributor to the extent caused by the acts or omissions of such Commercial Contributor in connection with its distribution of the Program in a commercial product offering. The obligations in this section do not apply to any claims or Losses relating to any actual or alleged intellectual property infringement. In order to qualify, an Indemnified Contributor must: a) promptly notify the Commercial Contributor in writing of such claim, and b) allow the Commercial Contributor to control, and cooperate with the Commercial Contributor in, the defense and any related settlement negotiations. The Indemnified Contributor may participate in any such claim at its own expense.
-
-For example, a Contributor might include the Program in a commercial product offering, Product X. That Contributor is then a Commercial Contributor. If that Commercial Contributor then makes performance claims, or offers warranties related to Product X, those performance claims and warranties are such Commercial Contributor&apos;s responsibility alone. Under this section, the Commercial Contributor would have to defend claims against the other Contributors related to those performance claims and warranties, and if a court requires any other Contributor to pay any damages as a result, the Commercial Contributor must pay those damages.
-
-5. NO WARRANTY
-
-EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely responsible for determining the appropriateness of using and distributing the Program and assumes all risks associated with its exercise of rights under this Agreement , including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and unavailability or interruption of operations.
-
-6. DISCLAIMER OF LIABILITY
-
-EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
-
-7. GENERAL
-
-If any provision of this Agreement is invalid or unenforceable under applicable law, it shall not affect the validity or enforceability of the remainder of the terms of this Agreement, and without further action by the parties hereto, such provision shall be reformed to the minimum extent necessary to make such provision valid and enforceable.
-
-If Recipient institutes patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Program itself (excluding combinations of the Program with other software or hardware) infringes such Recipient&apos;s patent(s), then such Recipient&apos;s rights granted under Section 2(b) shall terminate as of the date such litigation is filed.
-
-All Recipient&apos;s rights under this Agreement shall terminate if it fails to comply with any of the material terms or conditions of this Agreement and does not cure such failure in a reasonable period of time after becoming aware of such noncompliance. If all Recipient&apos;s rights under this Agreement terminate, Recipient agrees to cease use and distribution of the Program as soon as reasonably practicable. However, Recipient&apos;s obligations under this Agreement and any licenses granted by Recipient relating to the Program shall continue and survive.
-
-Everyone is permitted to copy and distribute copies of this Agreement, but in order to avoid inconsistency the Agreement is copyrighted and may only be modified in the following manner. The Agreement Steward reserves the right to publish new versions (including revisions) of this Agreement from time to time. No one other than the Agreement Steward has the right to modify this Agreement. The Eclipse Foundation is the initial Agreement Steward. The Eclipse Foundation may assign the responsibility to serve as the Agreement Steward to a suitable separate entity. Each new version of the Agreement will be given a distinguishing version number. The Program (including Contributions) may always be distributed subject to the version of the Agreement under which it was received. In addition, after a new version of the Agreement is published, Contributor may elect to distribute the Program (including its Contributions) under the new version. Except as expressly stated in Sections 2(a) and 2(b) above, Recipient receives no rights or licenses to the intellectual property of any Contributor under this Agreement, whether expressly, by implication, estoppel or otherwise. All rights in the Program not expressly granted under this Agreement are reserved.
-
-This Agreement is governed by the laws of the State of New York and the intellectual property laws of the United States of America. No party to this Agreement will bring a legal action under this Agreement more than one year after the cause of action arose. Each party waives its rights to a jury trial in any resulting litigation.
+   <license url="%licenseURL">
+      %license
    </license>
 
    <includes

--- a/features/it.xsemantics.implemented.examples.feature/feature.xml
+++ b/features/it.xsemantics.implemented.examples.feature/feature.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <feature
       id="it.xsemantics.implemented.examples.feature"
       label="Xsemantics Implemented Examples"

--- a/features/it.xsemantics.implemented.examples.feature/pom.xml
+++ b/features/it.xsemantics.implemented.examples.feature/pom.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/features/it.xsemantics.runtime.feature/feature.properties
+++ b/features/it.xsemantics.runtime.feature/feature.properties
@@ -1,0 +1,3 @@
+
+featureName = it.xsemantics.runtime.feature
+providerName = Eclipse Xsemantics Project

--- a/features/it.xsemantics.runtime.feature/feature.xml
+++ b/features/it.xsemantics.runtime.feature/feature.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <feature
       id="it.xsemantics.runtime.feature"
       label="Xsemantics Runtime Feature"

--- a/features/it.xsemantics.runtime.feature/feature.xml
+++ b/features/it.xsemantics.runtime.feature/feature.xml
@@ -13,7 +13,9 @@ Contributors:
       id="it.xsemantics.runtime.feature"
       label="Xsemantics Runtime Feature"
       version="1.12.1.qualifier"
-      provider-name="Lorenzo Bettini">
+      provider-name="%providerName"
+      license-feature="org.eclipse.license"
+      license-feature-version="1.0.1.v20140414-1359">
 
    <description url="http://xsemantics.sourceforge.net">
       Xsemantics is a DSL (implemented in Xtext itself) for writing
@@ -24,98 +26,19 @@ for scoping and validation (it can also generate a validator
 in Java).
    </description>
 
-   <copyright url="http://www.lorenzobettini.it">
-      2012, Lorenzo Bettini
+   <copyright>
+      Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
    </copyright>
 
-   <license url="http://www.eclipse.org/org/documents/epl-v10.html">
-      Eclipse Public License - v 1.0
-
-THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC LICENSE (&quot;AGREEMENT&quot;). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT&apos;S ACCEPTANCE OF THIS AGREEMENT.
-
-1. DEFINITIONS
-
-&quot;Contribution&quot; means:
-
-a) in the case of the initial Contributor, the initial code and documentation distributed under this Agreement, and
-
-b) in the case of each subsequent Contributor:
-
-i) changes to the Program, and
-
-ii) additions to the Program;
-
-where such changes and/or additions to the Program originate from and are distributed by that particular Contributor. A Contribution &apos;originates&apos; from a Contributor if it was added to the Program by such Contributor itself or anyone acting on such Contributor&apos;s behalf. Contributions do not include additions to the Program which: (i) are separate modules of software distributed in conjunction with the Program under their own license agreement, and (ii) are not derivative works of the Program.
-
-&quot;Contributor&quot; means any person or entity that distributes the Program.
-
-&quot;Licensed Patents&quot; mean patent claims licensable by a Contributor which are necessarily infringed by the use or sale of its Contribution alone or when combined with the Program.
-
-&quot;Program&quot; means the Contributions distributed in accordance with this Agreement.
-
-&quot;Recipient&quot; means anyone who receives the Program under this Agreement, including all Contributors.
-
-2. GRANT OF RIGHTS
-
-a) Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, distribute and sublicense the Contribution of such Contributor, if any, and such derivative works, in source code and object code form.
-
-b) Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free patent license under Licensed Patents to make, use, sell, offer to sell, import and otherwise transfer the Contribution of such Contributor, if any, in source code and object code form. This patent license shall apply to the combination of the Contribution and the Program if, at the time the Contribution is added by the Contributor, such addition of the Contribution causes such combination to be covered by the Licensed Patents. The patent license shall not apply to any other combinations which include the Contribution. No hardware per se is licensed hereunder.
-
-c) Recipient understands that although each Contributor grants the licenses to its Contributions set forth herein, no assurances are provided by any Contributor that the Program does not infringe the patent or other intellectual property rights of any other entity. Each Contributor disclaims any liability to Recipient for claims brought by any other entity based on infringement of intellectual property rights or otherwise. As a condition to exercising the rights and licenses granted hereunder, each Recipient hereby assumes sole responsibility to secure any other intellectual property rights needed, if any. For example, if a third party patent license is required to allow Recipient to distribute the Program, it is Recipient&apos;s responsibility to acquire that license before distributing the Program.
-
-d) Each Contributor represents that to its knowledge it has sufficient copyright rights in its Contribution, if any, to grant the copyright license set forth in this Agreement.
-
-3. REQUIREMENTS
-
-A Contributor may choose to distribute the Program in object code form under its own license agreement, provided that:
-
-a) it complies with the terms and conditions of this Agreement; and
-
-b) its license agreement:
-
-i) effectively disclaims on behalf of all Contributors all warranties and conditions, express and implied, including warranties or conditions of title and non-infringement, and implied warranties or conditions of merchantability and fitness for a particular purpose;
-
-ii) effectively excludes on behalf of all Contributors all liability for damages, including direct, indirect, special, incidental and consequential damages, such as lost profits;
-
-iii) states that any provisions which differ from this Agreement are offered by that Contributor alone and not by any other party; and
-
-iv) states that source code for the Program is available from such Contributor, and informs licensees how to obtain it in a reasonable manner on or through a medium customarily used for software exchange.
-
-When the Program is made available in source code form:
-
-a) it must be made available under this Agreement; and
-
-b) a copy of this Agreement must be included with each copy of the Program.
-
-Contributors may not remove or alter any copyright notices contained within the Program.
-
-Each Contributor must identify itself as the originator of its Contribution, if any, in a manner that reasonably allows subsequent Recipients to identify the originator of the Contribution.
-
-4. COMMERCIAL DISTRIBUTION
-
-Commercial distributors of software may accept certain responsibilities with respect to end users, business partners and the like. While this license is intended to facilitate the commercial use of the Program, the Contributor who includes the Program in a commercial product offering should do so in a manner which does not create potential liability for other Contributors. Therefore, if a Contributor includes the Program in a commercial product offering, such Contributor (&quot;Commercial Contributor&quot;) hereby agrees to defend and indemnify every other Contributor (&quot;Indemnified Contributor&quot;) against any losses, damages and costs (collectively &quot;Losses&quot;) arising from claims, lawsuits and other legal actions brought by a third party against the Indemnified Contributor to the extent caused by the acts or omissions of such Commercial Contributor in connection with its distribution of the Program in a commercial product offering. The obligations in this section do not apply to any claims or Losses relating to any actual or alleged intellectual property infringement. In order to qualify, an Indemnified Contributor must: a) promptly notify the Commercial Contributor in writing of such claim, and b) allow the Commercial Contributor to control, and cooperate with the Commercial Contributor in, the defense and any related settlement negotiations. The Indemnified Contributor may participate in any such claim at its own expense.
-
-For example, a Contributor might include the Program in a commercial product offering, Product X. That Contributor is then a Commercial Contributor. If that Commercial Contributor then makes performance claims, or offers warranties related to Product X, those performance claims and warranties are such Commercial Contributor&apos;s responsibility alone. Under this section, the Commercial Contributor would have to defend claims against the other Contributors related to those performance claims and warranties, and if a court requires any other Contributor to pay any damages as a result, the Commercial Contributor must pay those damages.
-
-5. NO WARRANTY
-
-EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely responsible for determining the appropriateness of using and distributing the Program and assumes all risks associated with its exercise of rights under this Agreement , including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and unavailability or interruption of operations.
-
-6. DISCLAIMER OF LIABILITY
-
-EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
-
-7. GENERAL
-
-If any provision of this Agreement is invalid or unenforceable under applicable law, it shall not affect the validity or enforceability of the remainder of the terms of this Agreement, and without further action by the parties hereto, such provision shall be reformed to the minimum extent necessary to make such provision valid and enforceable.
-
-If Recipient institutes patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Program itself (excluding combinations of the Program with other software or hardware) infringes such Recipient&apos;s patent(s), then such Recipient&apos;s rights granted under Section 2(b) shall terminate as of the date such litigation is filed.
-
-All Recipient&apos;s rights under this Agreement shall terminate if it fails to comply with any of the material terms or conditions of this Agreement and does not cure such failure in a reasonable period of time after becoming aware of such noncompliance. If all Recipient&apos;s rights under this Agreement terminate, Recipient agrees to cease use and distribution of the Program as soon as reasonably practicable. However, Recipient&apos;s obligations under this Agreement and any licenses granted by Recipient relating to the Program shall continue and survive.
-
-Everyone is permitted to copy and distribute copies of this Agreement, but in order to avoid inconsistency the Agreement is copyrighted and may only be modified in the following manner. The Agreement Steward reserves the right to publish new versions (including revisions) of this Agreement from time to time. No one other than the Agreement Steward has the right to modify this Agreement. The Eclipse Foundation is the initial Agreement Steward. The Eclipse Foundation may assign the responsibility to serve as the Agreement Steward to a suitable separate entity. Each new version of the Agreement will be given a distinguishing version number. The Program (including Contributions) may always be distributed subject to the version of the Agreement under which it was received. In addition, after a new version of the Agreement is published, Contributor may elect to distribute the Program (including its Contributions) under the new version. Except as expressly stated in Sections 2(a) and 2(b) above, Recipient receives no rights or licenses to the intellectual property of any Contributor under this Agreement, whether expressly, by implication, estoppel or otherwise. All rights in the Program not expressly granted under this Agreement are reserved.
-
-This Agreement is governed by the laws of the State of New York and the intellectual property laws of the United States of America. No party to this Agreement will bring a legal action under this Agreement more than one year after the cause of action arose. Each party waives its rights to a jury trial in any resulting litigation.
+   <license url="%licenseURL">
+      %license
    </license>
 
    <plugin

--- a/features/it.xsemantics.runtime.feature/pom.xml
+++ b/features/it.xsemantics.runtime.feature/pom.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/features/it.xsemantics.sdk/feature.properties
+++ b/features/it.xsemantics.sdk/feature.properties
@@ -1,3 +1,3 @@
 
-pluginName = it.xsemantics.dsl
+featureName = it.xsemantics.sdk
 providerName = Eclipse Xsemantics Project

--- a/features/it.xsemantics.sdk/feature.xml
+++ b/features/it.xsemantics.sdk/feature.xml
@@ -13,7 +13,9 @@ Contributors:
       id="it.xsemantics.sdk"
       label="Xsemantics SDK"
       version="1.12.1.qualifier"
-      provider-name="Lorenzo Bettini">
+      provider-name="%providerName"
+      license-feature="org.eclipse.license"
+      license-feature-version="1.0.1.v20140414-1359">
 
    <description url="http://xsemantics.sourceforge.net">
       Xsemantics is a DSL (implemented in Xtext itself) for writing
@@ -24,98 +26,19 @@ for scoping and validation (it can also generate a validator
 in Java).
    </description>
 
-   <copyright url="http://www.lorenzobettini.it">
-      2012, Lorenzo Bettini
+   <copyright>
+      Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
    </copyright>
 
-   <license url="http://www.eclipse.org/org/documents/epl-v10.html">
-      Eclipse Public License - v 1.0
-
-THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC LICENSE (&quot;AGREEMENT&quot;). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT&apos;S ACCEPTANCE OF THIS AGREEMENT.
-
-1. DEFINITIONS
-
-&quot;Contribution&quot; means:
-
-a) in the case of the initial Contributor, the initial code and documentation distributed under this Agreement, and
-
-b) in the case of each subsequent Contributor:
-
-i) changes to the Program, and
-
-ii) additions to the Program;
-
-where such changes and/or additions to the Program originate from and are distributed by that particular Contributor. A Contribution &apos;originates&apos; from a Contributor if it was added to the Program by such Contributor itself or anyone acting on such Contributor&apos;s behalf. Contributions do not include additions to the Program which: (i) are separate modules of software distributed in conjunction with the Program under their own license agreement, and (ii) are not derivative works of the Program.
-
-&quot;Contributor&quot; means any person or entity that distributes the Program.
-
-&quot;Licensed Patents&quot; mean patent claims licensable by a Contributor which are necessarily infringed by the use or sale of its Contribution alone or when combined with the Program.
-
-&quot;Program&quot; means the Contributions distributed in accordance with this Agreement.
-
-&quot;Recipient&quot; means anyone who receives the Program under this Agreement, including all Contributors.
-
-2. GRANT OF RIGHTS
-
-a) Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, distribute and sublicense the Contribution of such Contributor, if any, and such derivative works, in source code and object code form.
-
-b) Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free patent license under Licensed Patents to make, use, sell, offer to sell, import and otherwise transfer the Contribution of such Contributor, if any, in source code and object code form. This patent license shall apply to the combination of the Contribution and the Program if, at the time the Contribution is added by the Contributor, such addition of the Contribution causes such combination to be covered by the Licensed Patents. The patent license shall not apply to any other combinations which include the Contribution. No hardware per se is licensed hereunder.
-
-c) Recipient understands that although each Contributor grants the licenses to its Contributions set forth herein, no assurances are provided by any Contributor that the Program does not infringe the patent or other intellectual property rights of any other entity. Each Contributor disclaims any liability to Recipient for claims brought by any other entity based on infringement of intellectual property rights or otherwise. As a condition to exercising the rights and licenses granted hereunder, each Recipient hereby assumes sole responsibility to secure any other intellectual property rights needed, if any. For example, if a third party patent license is required to allow Recipient to distribute the Program, it is Recipient&apos;s responsibility to acquire that license before distributing the Program.
-
-d) Each Contributor represents that to its knowledge it has sufficient copyright rights in its Contribution, if any, to grant the copyright license set forth in this Agreement.
-
-3. REQUIREMENTS
-
-A Contributor may choose to distribute the Program in object code form under its own license agreement, provided that:
-
-a) it complies with the terms and conditions of this Agreement; and
-
-b) its license agreement:
-
-i) effectively disclaims on behalf of all Contributors all warranties and conditions, express and implied, including warranties or conditions of title and non-infringement, and implied warranties or conditions of merchantability and fitness for a particular purpose;
-
-ii) effectively excludes on behalf of all Contributors all liability for damages, including direct, indirect, special, incidental and consequential damages, such as lost profits;
-
-iii) states that any provisions which differ from this Agreement are offered by that Contributor alone and not by any other party; and
-
-iv) states that source code for the Program is available from such Contributor, and informs licensees how to obtain it in a reasonable manner on or through a medium customarily used for software exchange.
-
-When the Program is made available in source code form:
-
-a) it must be made available under this Agreement; and
-
-b) a copy of this Agreement must be included with each copy of the Program.
-
-Contributors may not remove or alter any copyright notices contained within the Program.
-
-Each Contributor must identify itself as the originator of its Contribution, if any, in a manner that reasonably allows subsequent Recipients to identify the originator of the Contribution.
-
-4. COMMERCIAL DISTRIBUTION
-
-Commercial distributors of software may accept certain responsibilities with respect to end users, business partners and the like. While this license is intended to facilitate the commercial use of the Program, the Contributor who includes the Program in a commercial product offering should do so in a manner which does not create potential liability for other Contributors. Therefore, if a Contributor includes the Program in a commercial product offering, such Contributor (&quot;Commercial Contributor&quot;) hereby agrees to defend and indemnify every other Contributor (&quot;Indemnified Contributor&quot;) against any losses, damages and costs (collectively &quot;Losses&quot;) arising from claims, lawsuits and other legal actions brought by a third party against the Indemnified Contributor to the extent caused by the acts or omissions of such Commercial Contributor in connection with its distribution of the Program in a commercial product offering. The obligations in this section do not apply to any claims or Losses relating to any actual or alleged intellectual property infringement. In order to qualify, an Indemnified Contributor must: a) promptly notify the Commercial Contributor in writing of such claim, and b) allow the Commercial Contributor to control, and cooperate with the Commercial Contributor in, the defense and any related settlement negotiations. The Indemnified Contributor may participate in any such claim at its own expense.
-
-For example, a Contributor might include the Program in a commercial product offering, Product X. That Contributor is then a Commercial Contributor. If that Commercial Contributor then makes performance claims, or offers warranties related to Product X, those performance claims and warranties are such Commercial Contributor&apos;s responsibility alone. Under this section, the Commercial Contributor would have to defend claims against the other Contributors related to those performance claims and warranties, and if a court requires any other Contributor to pay any damages as a result, the Commercial Contributor must pay those damages.
-
-5. NO WARRANTY
-
-EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely responsible for determining the appropriateness of using and distributing the Program and assumes all risks associated with its exercise of rights under this Agreement , including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and unavailability or interruption of operations.
-
-6. DISCLAIMER OF LIABILITY
-
-EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
-
-7. GENERAL
-
-If any provision of this Agreement is invalid or unenforceable under applicable law, it shall not affect the validity or enforceability of the remainder of the terms of this Agreement, and without further action by the parties hereto, such provision shall be reformed to the minimum extent necessary to make such provision valid and enforceable.
-
-If Recipient institutes patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Program itself (excluding combinations of the Program with other software or hardware) infringes such Recipient&apos;s patent(s), then such Recipient&apos;s rights granted under Section 2(b) shall terminate as of the date such litigation is filed.
-
-All Recipient&apos;s rights under this Agreement shall terminate if it fails to comply with any of the material terms or conditions of this Agreement and does not cure such failure in a reasonable period of time after becoming aware of such noncompliance. If all Recipient&apos;s rights under this Agreement terminate, Recipient agrees to cease use and distribution of the Program as soon as reasonably practicable. However, Recipient&apos;s obligations under this Agreement and any licenses granted by Recipient relating to the Program shall continue and survive.
-
-Everyone is permitted to copy and distribute copies of this Agreement, but in order to avoid inconsistency the Agreement is copyrighted and may only be modified in the following manner. The Agreement Steward reserves the right to publish new versions (including revisions) of this Agreement from time to time. No one other than the Agreement Steward has the right to modify this Agreement. The Eclipse Foundation is the initial Agreement Steward. The Eclipse Foundation may assign the responsibility to serve as the Agreement Steward to a suitable separate entity. Each new version of the Agreement will be given a distinguishing version number. The Program (including Contributions) may always be distributed subject to the version of the Agreement under which it was received. In addition, after a new version of the Agreement is published, Contributor may elect to distribute the Program (including its Contributions) under the new version. Except as expressly stated in Sections 2(a) and 2(b) above, Recipient receives no rights or licenses to the intellectual property of any Contributor under this Agreement, whether expressly, by implication, estoppel or otherwise. All rights in the Program not expressly granted under this Agreement are reserved.
-
-This Agreement is governed by the laws of the State of New York and the intellectual property laws of the United States of America. No party to this Agreement will bring a legal action under this Agreement more than one year after the cause of action arose. Each party waives its rights to a jury trial in any resulting litigation.
+   <license url="%licenseURL">
+      %license
    </license>
 
    <includes

--- a/features/it.xsemantics.sdk/feature.xml
+++ b/features/it.xsemantics.sdk/feature.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <feature
       id="it.xsemantics.sdk"
       label="Xsemantics SDK"

--- a/features/it.xsemantics.sdk/pom.xml
+++ b/features/it.xsemantics.sdk/pom.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/features/it.xsemantics.tests.feature/feature.properties
+++ b/features/it.xsemantics.tests.feature/feature.properties
@@ -1,3 +1,3 @@
 
-pluginName = it.xsemantics.dsl
+featureName = it.xsemantics.tests.feature
 providerName = Eclipse Xsemantics Project

--- a/features/it.xsemantics.tests.feature/feature.xml
+++ b/features/it.xsemantics.tests.feature/feature.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <feature
       id="it.xsemantics.tests.feature"
       label="Xsemantics Feature For Testing"

--- a/features/it.xsemantics.tests.feature/feature.xml
+++ b/features/it.xsemantics.tests.feature/feature.xml
@@ -13,18 +13,27 @@ Contributors:
       id="it.xsemantics.tests.feature"
       label="Xsemantics Feature For Testing"
       version="1.12.1.qualifier"
-      provider-name="Lorenzo Bettini">
+      provider-name="%providerName"
+      license-feature="org.eclipse.license"
+      license-feature-version="1.0.1.v20140414-1359">
 
    <description url="http://www.example.com/description">
       [Enter Feature Description here.]
    </description>
 
-   <copyright url="http://www.example.com/copyright">
-      [Enter Copyright Description here.]
+   <copyright>
+      Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
    </copyright>
 
-   <license url="http://www.example.com/license">
-      [Enter License Description here.]
+   <license url="%licenseURL">
+      %license
    </license>
 
    <includes

--- a/features/it.xsemantics.tests.feature/pom.xml
+++ b/features/it.xsemantics.tests.feature/pom.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/notice.html
+++ b/notice.html
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
+<title>Eclipse Foundation Software User Agreement</title>
+</head>
+
+<body lang="EN-US">
+<h2>Eclipse Foundation Software User Agreement</h2>
+<p>April 9, 2014</p>
+
+<h3>Usage Of Content</h3>
+
+<p>THE ECLIPSE FOUNDATION MAKES AVAILABLE SOFTWARE, DOCUMENTATION, INFORMATION AND/OR OTHER MATERIALS FOR OPEN SOURCE PROJECTS
+   (COLLECTIVELY &quot;CONTENT&quot;).  USE OF THE CONTENT IS GOVERNED BY THE TERMS AND CONDITIONS OF THIS AGREEMENT AND/OR THE TERMS AND
+   CONDITIONS OF LICENSE AGREEMENTS OR NOTICES INDICATED OR REFERENCED BELOW.  BY USING THE CONTENT, YOU AGREE THAT YOUR USE
+   OF THE CONTENT IS GOVERNED BY THIS AGREEMENT AND/OR THE TERMS AND CONDITIONS OF ANY APPLICABLE LICENSE AGREEMENTS OR
+   NOTICES INDICATED OR REFERENCED BELOW.  IF YOU DO NOT AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT AND THE TERMS AND
+   CONDITIONS OF ANY APPLICABLE LICENSE AGREEMENTS OR NOTICES INDICATED OR REFERENCED BELOW, THEN YOU MAY NOT USE THE CONTENT.</p>
+
+<h3>Applicable Licenses</h3>
+
+<p>Unless otherwise indicated, all Content made available by the Eclipse Foundation is provided to you under the terms and conditions of the Eclipse Public License Version 1.0
+   (&quot;EPL&quot;).  A copy of the EPL is provided with this Content and is also available at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+   For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>Content includes, but is not limited to, source code, object code, documentation and other files maintained in the Eclipse Foundation source code
+   repository (&quot;Repository&quot;) in software modules (&quot;Modules&quot;) and made available as downloadable archives (&quot;Downloads&quot;).</p>
+
+<ul>
+       <li>Content may be structured and packaged into modules to facilitate delivering, extending, and upgrading the Content.  Typical modules may include plug-ins (&quot;Plug-ins&quot;), plug-in fragments (&quot;Fragments&quot;), and features (&quot;Features&quot;).</li>
+       <li>Each Plug-in or Fragment may be packaged as a sub-directory or JAR (Java&trade; ARchive) in a directory named &quot;plugins&quot;.</li>
+       <li>A Feature is a bundle of one or more Plug-ins and/or Fragments and associated material.  Each Feature may be packaged as a sub-directory in a directory named &quot;features&quot;.  Within a Feature, files named &quot;feature.xml&quot; may contain a list of the names and version numbers of the Plug-ins
+      and/or Fragments associated with that Feature.</li>
+       <li>Features may also include other Features (&quot;Included Features&quot;). Within a Feature, files named &quot;feature.xml&quot; may contain a list of the names and version numbers of Included Features.</li>
+</ul>
+
+<p>The terms and conditions governing Plug-ins and Fragments should be contained in files named &quot;about.html&quot; (&quot;Abouts&quot;). The terms and conditions governing Features and
+Included Features should be contained in files named &quot;license.html&quot; (&quot;Feature Licenses&quot;).  Abouts and Feature Licenses may be located in any directory of a Download or Module
+including, but not limited to the following locations:</p>
+
+<ul>
+       <li>The top-level (root) directory</li>
+       <li>Plug-in and Fragment directories</li>
+       <li>Inside Plug-ins and Fragments packaged as JARs</li>
+       <li>Sub-directories of the directory named &quot;src&quot; of certain Plug-ins</li>
+       <li>Feature directories</li>
+</ul>
+
+<p>Note: if a Feature made available by the Eclipse Foundation is installed using the Provisioning Technology (as defined below), you must agree to a license (&quot;Feature Update License&quot;) during the
+installation process.  If the Feature contains Included Features, the Feature Update License should either provide you with the terms and conditions governing the Included Features or
+inform you where you can locate them.  Feature Update Licenses may be found in the &quot;license&quot; property of files named &quot;feature.properties&quot; found within a Feature.
+Such Abouts, Feature Licenses, and Feature Update Licenses contain the terms and conditions (or references to such terms and conditions) that govern your use of the associated Content in
+that directory.</p>
+
+<p>THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS.  SOME OF THESE
+OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):</p>
+
+<ul>
+       <li>Eclipse Distribution License Version 1.0 (available at <a href="http://www.eclipse.org/licenses/edl-v10.html">http://www.eclipse.org/licenses/edl-v1.0.html</a>)</li>
+       <li>Common Public License Version 1.0 (available at <a href="http://www.eclipse.org/legal/cpl-v10.html">http://www.eclipse.org/legal/cpl-v10.html</a>)</li>
+       <li>Apache Software License 1.1 (available at <a href="http://www.apache.org/licenses/LICENSE">http://www.apache.org/licenses/LICENSE</a>)</li>
+       <li>Apache Software License 2.0 (available at <a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a>)</li>
+       <li>Mozilla Public License Version 1.1 (available at <a href="http://www.mozilla.org/MPL/MPL-1.1.html">http://www.mozilla.org/MPL/MPL-1.1.html</a>)</li>
+</ul>
+
+<p>IT IS YOUR OBLIGATION TO READ AND ACCEPT ALL SUCH TERMS AND CONDITIONS PRIOR TO USE OF THE CONTENT.  If no About, Feature License, or Feature Update License is provided, please
+contact the Eclipse Foundation to determine what terms and conditions govern that particular Content.</p>
+
+
+<h3>Use of Provisioning Technology</h3>
+
+<p>The Eclipse Foundation makes available provisioning software, examples of which include, but are not limited to, p2 and the Eclipse
+   Update Manager (&quot;Provisioning Technology&quot;) for the purpose of allowing users to install software, documentation, information and/or
+   other materials (collectively &quot;Installable Software&quot;). This capability is provided with the intent of allowing such users to
+   install, extend and update Eclipse-based products. Information about packaging Installable Software is available at <a
+       href="http://eclipse.org/equinox/p2/repository_packaging.html">http://eclipse.org/equinox/p2/repository_packaging.html</a>
+   (&quot;Specification&quot;).</p>
+
+<p>You may use Provisioning Technology to allow other parties to install Installable Software. You shall be responsible for enabling the
+   applicable license agreements relating to the Installable Software to be presented to, and accepted by, the users of the Provisioning Technology
+   in accordance with the Specification. By using Provisioning Technology in such a manner and making it available in accordance with the
+   Specification, you further acknowledge your agreement to, and the acquisition of all necessary rights to permit the following:</p>
+
+<ol>
+       <li>A series of actions may occur (&quot;Provisioning Process&quot;) in which a user may execute the Provisioning Technology
+       on a machine (&quot;Target Machine&quot;) with the intent of installing, extending or updating the functionality of an Eclipse-based
+       product.</li>
+       <li>During the Provisioning Process, the Provisioning Technology may cause third party Installable Software or a portion thereof to be
+       accessed and copied to the Target Machine.</li>
+       <li>Pursuant to the Specification, you will provide to the user the terms and conditions that govern the use of the Installable
+       Software (&quot;Installable Software Agreement&quot;) and such Installable Software Agreement shall be accessed from the Target
+       Machine in accordance with the Specification. Such Installable Software Agreement must inform the user of the terms and conditions that govern
+       the Installable Software and must solicit acceptance by the end user in the manner prescribed in such Installable Software Agreement. Upon such
+       indication of agreement by the user, the provisioning Technology will complete installation of the Installable Software.</li>
+</ol>
+
+<h3>Cryptography</h3>
+
+<p>Content may contain encryption software. The country in which you are currently may have restrictions on the import, possession, and use, and/or re-export to
+   another country, of encryption software. BEFORE using any encryption software, please check the country's laws, regulations and policies concerning the import,
+   possession, or use, and re-export of encryption software, to see if this is permitted.</p>
+
+<p><small>Java and all Java-based trademarks are trademarks of Oracle Corporation in the United States, other countries, or both.</small></p>
+</body>
+</html>

--- a/plugins/it.xsemantics.dsl.ide/META-INF/MANIFEST.MF
+++ b/plugins/it.xsemantics.dsl.ide/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Xsemantics Generic Ide
 Bundle-SymbolicName: it.xsemantics.dsl.ide
 Bundle-Version: 1.12.1.qualifier
-Bundle-Vendor: Lorenzo Bettini
+Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: it.xsemantics.dsl,
  org.eclipse.xtext.ide,

--- a/plugins/it.xsemantics.dsl.ide/about.html
+++ b/plugins/it.xsemantics.dsl.ide/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>July 11, 2017</p>
+
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/plugins/it.xsemantics.dsl.ide/plugin.properties
+++ b/plugins/it.xsemantics.dsl.ide/plugin.properties
@@ -1,3 +1,3 @@
 
-pluginName = it.xsemantics.dsl
+pluginName = it.xsemantics.dsl.ide
 providerName = Eclipse Xsemantics Project

--- a/plugins/it.xsemantics.dsl.ide/pom.xml
+++ b/plugins/it.xsemantics.dsl.ide/pom.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/plugins/it.xsemantics.dsl.ui/META-INF/MANIFEST.MF
+++ b/plugins/it.xsemantics.dsl.ui/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Xsemantics UI
-Bundle-Vendor: Lorenzo Bettini
+Bundle-Vendor: %providerName
 Bundle-Version: 1.12.1.qualifier
 Bundle-SymbolicName: it.xsemantics.dsl.ui;singleton:=true
 Bundle-ActivationPolicy: lazy

--- a/plugins/it.xsemantics.dsl.ui/about.html
+++ b/plugins/it.xsemantics.dsl.ui/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>July 11, 2017</p>
+
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/plugins/it.xsemantics.dsl.ui/plugin.properties
+++ b/plugins/it.xsemantics.dsl.ui/plugin.properties
@@ -1,3 +1,3 @@
 
-pluginName = it.xsemantics.dsl
+pluginName = it.xsemantics.dsl.ui
 providerName = Eclipse Xsemantics Project

--- a/plugins/it.xsemantics.dsl.ui/plugin.xml
+++ b/plugins/it.xsemantics.dsl.ui/plugin.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <?eclipse version="3.0"?>
 <plugin>
 	<extension

--- a/plugins/it.xsemantics.dsl.ui/pom.xml
+++ b/plugins/it.xsemantics.dsl.ui/pom.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/plugins/it.xsemantics.dsl/META-INF/MANIFEST.MF
+++ b/plugins/it.xsemantics.dsl/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Xsemantics DSL
-Bundle-Vendor: Lorenzo Bettini
+Bundle-Vendor: %providerName
 Bundle-Version: 1.12.1.qualifier
 Bundle-ClassPath: .
 Bundle-SymbolicName: it.xsemantics.dsl;singleton:=true

--- a/plugins/it.xsemantics.dsl/about.html
+++ b/plugins/it.xsemantics.dsl/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>July 11, 2017</p>
+
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/plugins/it.xsemantics.dsl/old-mwe2/GenerateXsemanticsArtifacts.mwe2
+++ b/plugins/it.xsemantics.dsl/old-mwe2/GenerateXsemanticsArtifacts.mwe2
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ *******************************************************************************/
 module GenerateXsemanticsArtifacts
 
 import org.eclipse.emf.mwe.utils.*

--- a/plugins/it.xsemantics.dsl/old-mwe2/OldGenerateXsemantics.mwe2
+++ b/plugins/it.xsemantics.dsl/old-mwe2/OldGenerateXsemantics.mwe2
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ *******************************************************************************/
 module it.xsemantics.dsl.GenerateXsemantics
 
 import org.eclipse.emf.mwe.utils.*

--- a/plugins/it.xsemantics.dsl/plugin.xml
+++ b/plugins/it.xsemantics.dsl/plugin.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <?eclipse version="3.0"?>
 
 <plugin>

--- a/plugins/it.xsemantics.dsl/pom.xml
+++ b/plugins/it.xsemantics.dsl/pom.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/plugins/it.xsemantics.dsl/src/it/xsemantics/dsl/GenerateXsemantics.mwe2
+++ b/plugins/it.xsemantics.dsl/src/it/xsemantics/dsl/GenerateXsemantics.mwe2
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ *******************************************************************************/
 module it.xsemantics.dsl.GenerateXsemantics
 
 import org.eclipse.xtext.xtext.generator.*

--- a/plugins/it.xsemantics.dsl/src/it/xsemantics/dsl/GenerateXsemanticsModelClasses.mwe2
+++ b/plugins/it.xsemantics.dsl/src/it/xsemantics/dsl/GenerateXsemanticsModelClasses.mwe2
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ *******************************************************************************/
 module it.xsemantics.dsl.GenerateXsemanticsModelClasses
 
 import org.eclipse.xtext.xtext.generator.*

--- a/plugins/it.xsemantics.dsl/src/it/xsemantics/dsl/generator/XsemanticsGeneratorMWE.mwe2
+++ b/plugins/it.xsemantics.dsl/src/it/xsemantics/dsl/generator/XsemanticsGeneratorMWE.mwe2
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ *******************************************************************************/
 
 module it.xsemantics.dsl.generator.XsemanticsGeneratorMWE
 

--- a/plugins/it.xsemantics.dsl/src/it/xsemantics/dsl/typing/XsemanticsTypeSystem.xsemantics
+++ b/plugins/it.xsemantics.dsl/src/it/xsemantics/dsl/typing/XsemanticsTypeSystem.xsemantics
@@ -11,6 +11,17 @@
 
 system it.xsemantics.dsl.typing.XsemanticsTypeSystemGen
 
+copyright
+"Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API"
+
+
 validatorExtends it.xsemantics.dsl.validation.AbstractXsemanticsValidator
 
 import it.xsemantics.dsl.xsemantics.AuxiliaryDescription

--- a/plugins/it.xsemantics.runtime/META-INF/MANIFEST.MF
+++ b/plugins/it.xsemantics.runtime/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Xsemantics Runtime
 Bundle-SymbolicName: it.xsemantics.runtime;singleton:=true
 Bundle-Version: 1.12.1.qualifier
-Bundle-Vendor: Lorenzo Bettini
+Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.5.0",
  org.eclipse.emf.ecore;bundle-version="2.7.0";visibility:=reexport,
  org.eclipse.xtext.util,

--- a/plugins/it.xsemantics.runtime/about.html
+++ b/plugins/it.xsemantics.runtime/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>July 11, 2017</p>
+
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/plugins/it.xsemantics.runtime/about.html_TEMPLATE
+++ b/plugins/it.xsemantics.runtime/about.html_TEMPLATE
@@ -1,0 +1,36 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>July 11, 2017</p>                                              <!-- <<<<<<<<<< INSERT CURRENT RELEASE DATE HERE -->
+
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+<h3>Third Party Content</h3>
+<p>The Content includes items that have been sourced from third parties as set out below. If you 
+did not receive this Content directly from the Eclipse Foundation, the following is provided 
+for informational purposes only, and you should look to the Redistributor's license for 
+terms and conditions of use.</p>
+
+                <!-- ADD NOTICE ON THIRD PARTY CONTENT HERE OR DELETE ENTIRE SECTION "<h3>Third Party Content</h3>" -->
+
+</body>
+</html>

--- a/plugins/it.xsemantics.runtime/plugin.properties
+++ b/plugins/it.xsemantics.runtime/plugin.properties
@@ -1,3 +1,3 @@
 
-pluginName = it.xsemantics.dsl
+pluginName = it.xsemantics.runtime
 providerName = Eclipse Xsemantics Project

--- a/plugins/it.xsemantics.runtime/pom.xml
+++ b/plugins/it.xsemantics.runtime/pom.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/releng/it.xsemantics.maven.releng/about.html
+++ b/releng/it.xsemantics.maven.releng/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>July 11, 2017</p>
+
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/releng/it.xsemantics.maven.releng/plugin.properties
+++ b/releng/it.xsemantics.maven.releng/plugin.properties
@@ -1,3 +1,3 @@
 
-pluginName = it.xsemantics.dsl
+pluginName = it.xsemantics.maven.releng
 providerName = Eclipse Xsemantics Project

--- a/releng/it.xsemantics.maven.releng/pom.xml
+++ b/releng/it.xsemantics.maven.releng/pom.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/releng/it.xsemantics.parent/about.html
+++ b/releng/it.xsemantics.parent/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>July 11, 2017</p>
+
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/releng/it.xsemantics.parent/findbugs/excludeFilter.xml
+++ b/releng/it.xsemantics.parent/findbugs/excludeFilter.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <FindBugsFilter>
 	<!-- sources of tests -->
 	<Match>

--- a/releng/it.xsemantics.parent/findbugs/excludeFilter.xml
+++ b/releng/it.xsemantics.parent/findbugs/excludeFilter.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <FindBugsFilter>
 	<!-- sources of tests -->
 	<Match>

--- a/releng/it.xsemantics.parent/plugin.properties
+++ b/releng/it.xsemantics.parent/plugin.properties
@@ -1,3 +1,3 @@
 
-pluginName = it.xsemantics.dsl
+pluginName = it.xsemantics.parent
 providerName = Eclipse Xsemantics Project

--- a/releng/it.xsemantics.parent/pom.xml
+++ b/releng/it.xsemantics.parent/pom.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/releng/it.xsemantics.releng/about.html
+++ b/releng/it.xsemantics.releng/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>July 11, 2017</p>
+
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/releng/it.xsemantics.releng/plugin.properties
+++ b/releng/it.xsemantics.releng/plugin.properties
@@ -1,3 +1,3 @@
 
-pluginName = it.xsemantics.dsl
+pluginName = it.xsemantics.releng
 providerName = Eclipse Xsemantics Project

--- a/releng/it.xsemantics.releng/pom.xml
+++ b/releng/it.xsemantics.releng/pom.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/releng/it.xsemantics.repository/about.html
+++ b/releng/it.xsemantics.repository/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>July 11, 2017</p>
+
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/releng/it.xsemantics.repository/category.xml
+++ b/releng/it.xsemantics.repository/category.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <site>
    <description name="Xsemantics" url="http://xsemantics.sourceforge.net">
       Xsemantics is a DSL (implemented in Xtext itself) for writing

--- a/releng/it.xsemantics.repository/plugin.properties
+++ b/releng/it.xsemantics.repository/plugin.properties
@@ -1,3 +1,3 @@
 
-pluginName = it.xsemantics.dsl
+pluginName = it.xsemantics.repository
 providerName = Eclipse Xsemantics Project

--- a/releng/it.xsemantics.repository/pom.xml
+++ b/releng/it.xsemantics.repository/pom.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/tests/it.xsemantics.dsl.tests/META-INF/MANIFEST.MF
+++ b/tests/it.xsemantics.dsl.tests/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: it.xsemantics.dsl.xsemantics.tests
-Bundle-Vendor: Lorenzo Bettini
+Bundle-Vendor: %providerName
 Bundle-Version: 1.12.1.qualifier
 Bundle-SymbolicName: it.xsemantics.dsl.tests;singleton:=true
 Bundle-ActivationPolicy: lazy

--- a/tests/it.xsemantics.dsl.tests/about.html
+++ b/tests/it.xsemantics.dsl.tests/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>July 11, 2017</p>
+
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/tests/it.xsemantics.dsl.tests/expectations/ecore_errspecification_test/it/xsemantics/test/errspecification/ecore/TypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/ecore_errspecification_test/it/xsemantics/test/errspecification/ecore/TypeSystem.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.errspecification.ecore;
 
 import com.google.inject.Provider;

--- a/tests/it.xsemantics.dsl.tests/expectations/ecore_errspecification_test/it/xsemantics/test/errspecification/ecore/TypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/ecore_errspecification_test/it/xsemantics/test/errspecification/ecore/TypeSystem.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.errspecification.ecore;
 
 import com.google.inject.Provider;

--- a/tests/it.xsemantics.dsl.tests/expectations/ecore_errspecification_test/it/xsemantics/test/errspecification/ecore/validation/TypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/ecore_errspecification_test/it/xsemantics/test/errspecification/ecore/validation/TypeSystemValidator.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.errspecification.ecore.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/expectations/ecore_errspecification_test/it/xsemantics/test/errspecification/ecore/validation/TypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/ecore_errspecification_test/it/xsemantics/test/errspecification/ecore/validation/TypeSystemValidator.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.errspecification.ecore.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/expectations/ecore_expressions_test/it/xsemantics/test/expressions/ecore/TypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/ecore_expressions_test/it/xsemantics/test/expressions/ecore/TypeSystem.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.expressions.ecore;
 
 import com.google.common.base.Objects;

--- a/tests/it.xsemantics.dsl.tests/expectations/ecore_expressions_test/it/xsemantics/test/expressions/ecore/TypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/ecore_expressions_test/it/xsemantics/test/expressions/ecore/TypeSystem.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.expressions.ecore;
 
 import com.google.common.base.Objects;
@@ -15,14 +25,7 @@ import org.eclipse.xtext.util.PolymorphicDispatcher;
 import org.eclipse.xtext.xbase.lib.StringExtensions;
 
 /**
- * Copyright (c) 2013-2017 Lorenzo Bettini.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- * 
- * Contributors:
- *   Lorenzo Bettini - Initial contribution and API
+ * some particular cases
  */
 @SuppressWarnings("all")
 public class TypeSystem extends XsemanticsRuntimeSystem {

--- a/tests/it.xsemantics.dsl.tests/expectations/ecore_expressions_test/it/xsemantics/test/expressions/ecore/validation/TypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/ecore_expressions_test/it/xsemantics/test/expressions/ecore/validation/TypeSystemValidator.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.expressions.ecore.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/expectations/ecore_expressions_test/it/xsemantics/test/expressions/ecore/validation/TypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/ecore_expressions_test/it/xsemantics/test/expressions/ecore/validation/TypeSystemValidator.java
@@ -1,10 +1,3 @@
-package it.xsemantics.test.expressions.ecore.validation;
-
-import com.google.inject.Inject;
-import it.xsemantics.runtime.validation.XsemanticsValidatorErrorGenerator;
-import it.xsemantics.test.expressions.ecore.TypeSystem;
-import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
-
 /**
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
@@ -14,6 +7,16 @@ import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
  * 
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
+ */
+package it.xsemantics.test.expressions.ecore.validation;
+
+import com.google.inject.Inject;
+import it.xsemantics.runtime.validation.XsemanticsValidatorErrorGenerator;
+import it.xsemantics.test.expressions.ecore.TypeSystem;
+import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
+
+/**
+ * some particular cases
  */
 @SuppressWarnings("all")
 public class TypeSystemValidator extends AbstractDeclarativeValidator {

--- a/tests/it.xsemantics.dsl.tests/expectations/ecore_or_test/it/xsemantics/test/orexpressions/ecore/TypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/ecore_or_test/it/xsemantics/test/orexpressions/ecore/TypeSystem.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.orexpressions.ecore;
 
 import com.google.common.base.Objects;
@@ -13,14 +23,7 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.util.PolymorphicDispatcher;
 
 /**
- * Copyright (c) 2013-2017 Lorenzo Bettini.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- * 
- * Contributors:
- *   Lorenzo Bettini - Initial contribution and API
+ * some particular cases
  */
 @SuppressWarnings("all")
 public class TypeSystem extends XsemanticsRuntimeSystem {

--- a/tests/it.xsemantics.dsl.tests/expectations/ecore_or_test/it/xsemantics/test/orexpressions/ecore/TypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/ecore_or_test/it/xsemantics/test/orexpressions/ecore/TypeSystem.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.orexpressions.ecore;
 
 import com.google.common.base.Objects;

--- a/tests/it.xsemantics.dsl.tests/expectations/ecore_or_test/it/xsemantics/test/orexpressions/ecore/validation/TypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/ecore_or_test/it/xsemantics/test/orexpressions/ecore/validation/TypeSystemValidator.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.orexpressions.ecore.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/expectations/ecore_or_test/it/xsemantics/test/orexpressions/ecore/validation/TypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/ecore_or_test/it/xsemantics/test/orexpressions/ecore/validation/TypeSystemValidator.java
@@ -1,10 +1,3 @@
-package it.xsemantics.test.orexpressions.ecore.validation;
-
-import com.google.inject.Inject;
-import it.xsemantics.runtime.validation.XsemanticsValidatorErrorGenerator;
-import it.xsemantics.test.orexpressions.ecore.TypeSystem;
-import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
-
 /**
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
@@ -14,6 +7,16 @@ import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
  * 
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
+ */
+package it.xsemantics.test.orexpressions.ecore.validation;
+
+import com.google.inject.Inject;
+import it.xsemantics.runtime.validation.XsemanticsValidatorErrorGenerator;
+import it.xsemantics.test.orexpressions.ecore.TypeSystem;
+import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
+
+/**
+ * some particular cases
  */
 @SuppressWarnings("all")
 public class TypeSystemValidator extends AbstractDeclarativeValidator {

--- a/tests/it.xsemantics.dsl.tests/expectations/ecore_particular_test/it/xsemantics/test/particular/ecore/TypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/ecore_particular_test/it/xsemantics/test/particular/ecore/TypeSystem.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.particular.ecore;
 
 import com.google.common.base.Objects;
@@ -21,14 +31,7 @@ import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.StringExtensions;
 
 /**
- * Copyright (c) 2013-2017 Lorenzo Bettini.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- * 
- * Contributors:
- *   Lorenzo Bettini - Initial contribution and API
+ * some particular cases
  */
 @SuppressWarnings("all")
 public class TypeSystem extends XsemanticsRuntimeSystem {

--- a/tests/it.xsemantics.dsl.tests/expectations/ecore_particular_test/it/xsemantics/test/particular/ecore/TypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/ecore_particular_test/it/xsemantics/test/particular/ecore/TypeSystem.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.particular.ecore;
 
 import com.google.common.base.Objects;

--- a/tests/it.xsemantics.dsl.tests/expectations/ecore_particular_test/it/xsemantics/test/particular/ecore/validation/TypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/ecore_particular_test/it/xsemantics/test/particular/ecore/validation/TypeSystemValidator.java
@@ -1,10 +1,3 @@
-package it.xsemantics.test.particular.ecore.validation;
-
-import com.google.inject.Inject;
-import it.xsemantics.runtime.validation.XsemanticsValidatorErrorGenerator;
-import it.xsemantics.test.particular.ecore.TypeSystem;
-import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
-
 /**
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
@@ -14,6 +7,16 @@ import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
  * 
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
+ */
+package it.xsemantics.test.particular.ecore.validation;
+
+import com.google.inject.Inject;
+import it.xsemantics.runtime.validation.XsemanticsValidatorErrorGenerator;
+import it.xsemantics.test.particular.ecore.TypeSystem;
+import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
+
+/**
+ * some particular cases
  */
 @SuppressWarnings("all")
 public class TypeSystemValidator extends AbstractDeclarativeValidator {

--- a/tests/it.xsemantics.dsl.tests/expectations/ecore_particular_test/it/xsemantics/test/particular/ecore/validation/TypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/ecore_particular_test/it/xsemantics/test/particular/ecore/validation/TypeSystemValidator.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.particular.ecore.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/expectations/ecore_ruleinvocation_test/it/xsemantics/test/ruleinvocation/ecore/TypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/ecore_ruleinvocation_test/it/xsemantics/test/ruleinvocation/ecore/TypeSystem.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.ruleinvocation.ecore;
 
 import com.google.common.base.Objects;

--- a/tests/it.xsemantics.dsl.tests/expectations/ecore_ruleinvocation_test/it/xsemantics/test/ruleinvocation/ecore/TypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/ecore_ruleinvocation_test/it/xsemantics/test/ruleinvocation/ecore/TypeSystem.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.ruleinvocation.ecore;
 
 import com.google.common.base.Objects;
@@ -16,16 +26,6 @@ import org.eclipse.emf.ecore.EcoreFactory;
 import org.eclipse.xtext.util.PolymorphicDispatcher;
 import org.eclipse.xtext.xbase.lib.StringExtensions;
 
-/**
- * Copyright (c) 2013-2017 Lorenzo Bettini.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- * 
- * Contributors:
- *   Lorenzo Bettini - Initial contribution and API
- */
 @SuppressWarnings("all")
 public class TypeSystem extends XsemanticsRuntimeSystem {
   public final static String ECLASSEOBJECT = "it.xsemantics.test.ruleinvocation.ecore.EClassEObject";

--- a/tests/it.xsemantics.dsl.tests/expectations/ecore_ruleinvocation_test/it/xsemantics/test/ruleinvocation/ecore/validation/TypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/ecore_ruleinvocation_test/it/xsemantics/test/ruleinvocation/ecore/validation/TypeSystemValidator.java
@@ -1,10 +1,3 @@
-package it.xsemantics.test.ruleinvocation.ecore.validation;
-
-import com.google.inject.Inject;
-import it.xsemantics.runtime.validation.XsemanticsValidatorErrorGenerator;
-import it.xsemantics.test.ruleinvocation.ecore.TypeSystem;
-import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
-
 /**
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
@@ -15,6 +8,13 @@ import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
  */
+package it.xsemantics.test.ruleinvocation.ecore.validation;
+
+import com.google.inject.Inject;
+import it.xsemantics.runtime.validation.XsemanticsValidatorErrorGenerator;
+import it.xsemantics.test.ruleinvocation.ecore.TypeSystem;
+import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
+
 @SuppressWarnings("all")
 public class TypeSystemValidator extends AbstractDeclarativeValidator {
   @Inject

--- a/tests/it.xsemantics.dsl.tests/expectations/ecore_ruleinvocation_test/it/xsemantics/test/ruleinvocation/ecore/validation/TypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/ecore_ruleinvocation_test/it/xsemantics/test/ruleinvocation/ecore/validation/TypeSystemValidator.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.ruleinvocation.ecore.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/expectations/ecore_test/it/xsemantics/test/ecore/TypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/ecore_test/it/xsemantics/test/ecore/TypeSystem.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.ecore;
 
 import com.google.common.base.Objects;
@@ -14,16 +24,6 @@ import org.eclipse.emf.ecore.EcoreFactory;
 import org.eclipse.xtext.util.PolymorphicDispatcher;
 import org.eclipse.xtext.xbase.lib.StringExtensions;
 
-/**
- * Copyright (c) 2013-2017 Lorenzo Bettini.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- * 
- * Contributors:
- *   Lorenzo Bettini - Initial contribution and API
- */
 @SuppressWarnings("all")
 public class TypeSystem extends XsemanticsRuntimeSystem {
   public final static String ECLASSEOBJECT = "it.xsemantics.test.ecore.EClassEObject";

--- a/tests/it.xsemantics.dsl.tests/expectations/ecore_test/it/xsemantics/test/ecore/TypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/ecore_test/it/xsemantics/test/ecore/TypeSystem.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.ecore;
 
 import com.google.common.base.Objects;

--- a/tests/it.xsemantics.dsl.tests/expectations/ecore_test/it/xsemantics/test/ecore/validation/TypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/ecore_test/it/xsemantics/test/ecore/validation/TypeSystemValidator.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.ecore.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/expectations/ecore_test/it/xsemantics/test/ecore/validation/TypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/ecore_test/it/xsemantics/test/ecore/validation/TypeSystemValidator.java
@@ -1,10 +1,3 @@
-package it.xsemantics.test.ecore.validation;
-
-import com.google.inject.Inject;
-import it.xsemantics.runtime.validation.XsemanticsValidatorErrorGenerator;
-import it.xsemantics.test.ecore.TypeSystem;
-import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
-
 /**
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
@@ -15,6 +8,13 @@ import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
  */
+package it.xsemantics.test.ecore.validation;
+
+import com.google.inject.Inject;
+import it.xsemantics.runtime.validation.XsemanticsValidatorErrorGenerator;
+import it.xsemantics.test.ecore.TypeSystem;
+import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
+
 @SuppressWarnings("all")
 public class TypeSystemValidator extends AbstractDeclarativeValidator {
   @Inject

--- a/tests/it.xsemantics.dsl.tests/expectations/ecore_validation_test/it/xsemantics/test/validation/ecore/TypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/ecore_validation_test/it/xsemantics/test/validation/ecore/TypeSystem.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.validation.ecore;
 
 import com.google.common.base.Objects;

--- a/tests/it.xsemantics.dsl.tests/expectations/ecore_validation_test/it/xsemantics/test/validation/ecore/TypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/ecore_validation_test/it/xsemantics/test/validation/ecore/TypeSystem.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.validation.ecore;
 
 import com.google.common.base.Objects;
@@ -14,14 +24,7 @@ import org.eclipse.xtext.util.PolymorphicDispatcher;
 import org.eclipse.xtext.xbase.lib.StringExtensions;
 
 /**
- * Copyright (c) 2013-2017 Lorenzo Bettini.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- * 
- * Contributors:
- *   Lorenzo Bettini - Initial contribution and API
+ * some particular cases
  */
 @SuppressWarnings("all")
 public class TypeSystem extends XsemanticsRuntimeSystem {

--- a/tests/it.xsemantics.dsl.tests/expectations/ecore_validation_test/it/xsemantics/test/validation/ecore/validation/TypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/ecore_validation_test/it/xsemantics/test/validation/ecore/validation/TypeSystemValidator.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.validation.ecore.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/expectations/ecore_validation_test/it/xsemantics/test/validation/ecore/validation/TypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/ecore_validation_test/it/xsemantics/test/validation/ecore/validation/TypeSystemValidator.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.validation.ecore.validation;
 
 import com.google.inject.Inject;
@@ -8,14 +18,7 @@ import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
 import org.eclipse.xtext.validation.Check;
 
 /**
- * Copyright (c) 2013-2017 Lorenzo Bettini.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- * 
- * Contributors:
- *   Lorenzo Bettini - Initial contribution and API
+ * some particular cases
  */
 @SuppressWarnings("all")
 public class TypeSystemValidator extends AbstractDeclarativeValidator {

--- a/tests/it.xsemantics.dsl.tests/expectations/fj_alt_test/it/xsemantics/test/fj/alt/FjAltTypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/fj_alt_test/it/xsemantics/test/fj/alt/FjAltTypeSystem.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.fj.alt;
 
 import com.google.common.base.Objects;

--- a/tests/it.xsemantics.dsl.tests/expectations/fj_alt_test/it/xsemantics/test/fj/alt/FjAltTypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/fj_alt_test/it/xsemantics/test/fj/alt/FjAltTypeSystem.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.fj.alt;
 
 import com.google.common.base.Objects;

--- a/tests/it.xsemantics.dsl.tests/expectations/fj_alt_test/it/xsemantics/test/fj/alt/validation/FjAltTypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/fj_alt_test/it/xsemantics/test/fj/alt/validation/FjAltTypeSystemValidator.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.fj.alt.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/expectations/fj_alt_test/it/xsemantics/test/fj/alt/validation/FjAltTypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/fj_alt_test/it/xsemantics/test/fj/alt/validation/FjAltTypeSystemValidator.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.fj.alt.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/expectations/fj_cached_options_test/it/xsemantics/test/fj/caching/FjFirstCachedOptionsTypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/fj_cached_options_test/it/xsemantics/test/fj/caching/FjFirstCachedOptionsTypeSystem.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.fj.caching;
 
 import it.xsemantics.example.fj.fj.BasicType;

--- a/tests/it.xsemantics.dsl.tests/expectations/fj_cached_options_test/it/xsemantics/test/fj/caching/FjFirstCachedOptionsTypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/fj_cached_options_test/it/xsemantics/test/fj/caching/FjFirstCachedOptionsTypeSystem.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.fj.caching;
 
 import it.xsemantics.example.fj.fj.BasicType;

--- a/tests/it.xsemantics.dsl.tests/expectations/fj_cached_options_test/it/xsemantics/test/fj/caching/validation/FjFirstCachedOptionsTypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/fj_cached_options_test/it/xsemantics/test/fj/caching/validation/FjFirstCachedOptionsTypeSystemValidator.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.fj.caching.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/expectations/fj_cached_options_test/it/xsemantics/test/fj/caching/validation/FjFirstCachedOptionsTypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/fj_cached_options_test/it/xsemantics/test/fj/caching/validation/FjFirstCachedOptionsTypeSystemValidator.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.fj.caching.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/expectations/fj_cached_test/it/xsemantics/test/fj/caching/FjFirstCachedTypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/fj_cached_test/it/xsemantics/test/fj/caching/FjFirstCachedTypeSystem.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.fj.caching;
 
 import it.xsemantics.example.fj.fj.Expression;

--- a/tests/it.xsemantics.dsl.tests/expectations/fj_cached_test/it/xsemantics/test/fj/caching/FjFirstCachedTypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/fj_cached_test/it/xsemantics/test/fj/caching/FjFirstCachedTypeSystem.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.fj.caching;
 
 import it.xsemantics.example.fj.fj.Expression;

--- a/tests/it.xsemantics.dsl.tests/expectations/fj_cached_test/it/xsemantics/test/fj/caching/validation/FjFirstCachedTypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/fj_cached_test/it/xsemantics/test/fj/caching/validation/FjFirstCachedTypeSystemValidator.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.fj.caching.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/expectations/fj_cached_test/it/xsemantics/test/fj/caching/validation/FjFirstCachedTypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/fj_cached_test/it/xsemantics/test/fj/caching/validation/FjFirstCachedTypeSystemValidator.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.fj.caching.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/expectations/fj_first_test/it/xsemantics/test/fj/first/FjFirstTypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/fj_first_test/it/xsemantics/test/fj/first/FjFirstTypeSystem.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.fj.first;
 
 import com.google.common.base.Objects;

--- a/tests/it.xsemantics.dsl.tests/expectations/fj_first_test/it/xsemantics/test/fj/first/FjFirstTypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/fj_first_test/it/xsemantics/test/fj/first/FjFirstTypeSystem.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.fj.first;
 
 import com.google.common.base.Objects;

--- a/tests/it.xsemantics.dsl.tests/expectations/fj_first_test/it/xsemantics/test/fj/first/validation/FjFirstTypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/fj_first_test/it/xsemantics/test/fj/first/validation/FjFirstTypeSystemValidator.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.fj.first.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/expectations/fj_first_test/it/xsemantics/test/fj/first/validation/FjFirstTypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/fj_first_test/it/xsemantics/test/fj/first/validation/FjFirstTypeSystemValidator.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.fj.first.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/expectations/fj_lambda_test/it/xsemantics/test/fj/lambda/FjTestsForLambdas.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/fj_lambda_test/it/xsemantics/test/fj/lambda/FjTestsForLambdas.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.fj.lambda;
 
 import com.google.inject.Inject;
@@ -17,14 +27,7 @@ import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.ListExtensions;
 
 /**
- * Copyright (c) 2013-2017 Lorenzo Bettini.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- * 
- * Contributors:
- *   Lorenzo Bettini - Initial contribution and API
+ * Uses rule invocations as boolean expressions
  */
 @SuppressWarnings("all")
 public class FjTestsForLambdas extends FjFirstTypeSystem {

--- a/tests/it.xsemantics.dsl.tests/expectations/fj_lambda_test/it/xsemantics/test/fj/lambda/FjTestsForLambdas.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/fj_lambda_test/it/xsemantics/test/fj/lambda/FjTestsForLambdas.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.fj.lambda;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/expectations/fj_lambda_test/it/xsemantics/test/fj/lambda/validation/FjTestsForLambdasValidator.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/fj_lambda_test/it/xsemantics/test/fj/lambda/validation/FjTestsForLambdasValidator.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.fj.lambda.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/expectations/fj_lambda_test/it/xsemantics/test/fj/lambda/validation/FjTestsForLambdasValidator.java
+++ b/tests/it.xsemantics.dsl.tests/expectations/fj_lambda_test/it/xsemantics/test/fj/lambda/validation/FjTestsForLambdasValidator.java
@@ -1,9 +1,3 @@
-package it.xsemantics.test.fj.lambda.validation;
-
-import com.google.inject.Inject;
-import it.xsemantics.test.fj.first.validation.FjFirstTypeSystemValidator;
-import it.xsemantics.test.fj.lambda.FjTestsForLambdas;
-
 /**
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
@@ -13,6 +7,15 @@ import it.xsemantics.test.fj.lambda.FjTestsForLambdas;
  * 
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
+ */
+package it.xsemantics.test.fj.lambda.validation;
+
+import com.google.inject.Inject;
+import it.xsemantics.test.fj.first.validation.FjFirstTypeSystemValidator;
+import it.xsemantics.test.fj.lambda.FjTestsForLambdas;
+
+/**
+ * Uses rule invocations as boolean expressions
  */
 @SuppressWarnings("all")
 public class FjTestsForLambdasValidator extends FjFirstTypeSystemValidator {

--- a/tests/it.xsemantics.dsl.tests/old/pom_test_categories.xml
+++ b/tests/it.xsemantics.dsl.tests/old/pom_test_categories.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <project>
   <modelVersion>4.0.0</modelVersion>
 

--- a/tests/it.xsemantics.dsl.tests/plugin.properties
+++ b/tests/it.xsemantics.dsl.tests/plugin.properties
@@ -1,3 +1,3 @@
 
-pluginName = it.xsemantics.dsl
+pluginName = it.xsemantics.dsl.tests
 providerName = Eclipse Xsemantics Project

--- a/tests/it.xsemantics.dsl.tests/pom.xml
+++ b/tests/it.xsemantics.dsl.tests/pom.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/tests/it.xsemantics.dsl.tests/src/it/xsemantics/dsl/tests/generator/XsemanticsGeneratedFileHeaderTest.xtend
+++ b/tests/it.xsemantics.dsl.tests/src/it/xsemantics/dsl/tests/generator/XsemanticsGeneratedFileHeaderTest.xtend
@@ -9,17 +9,6 @@
  *   Lorenzo Bettini - Initial contribution and API
  *******************************************************************************/
 
-/**
- * Copyright (c) 2017 NumberFour AG.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- * 
- * Contributors:
- *   Jens von Pilgrim - Initial API and implementation
- */
-
 package it.xsemantics.dsl.tests.generator
 
 import com.google.inject.Inject

--- a/tests/it.xsemantics.dsl.tests/test-gen/ecore_errspecification_test/it/xsemantics/test/errspecification/ecore/TypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/ecore_errspecification_test/it/xsemantics/test/errspecification/ecore/TypeSystem.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.errspecification.ecore;
 
 import com.google.inject.Provider;

--- a/tests/it.xsemantics.dsl.tests/test-gen/ecore_errspecification_test/it/xsemantics/test/errspecification/ecore/TypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/ecore_errspecification_test/it/xsemantics/test/errspecification/ecore/TypeSystem.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.errspecification.ecore;
 
 import com.google.inject.Provider;

--- a/tests/it.xsemantics.dsl.tests/test-gen/ecore_errspecification_test/it/xsemantics/test/errspecification/ecore/validation/TypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/ecore_errspecification_test/it/xsemantics/test/errspecification/ecore/validation/TypeSystemValidator.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.errspecification.ecore.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/test-gen/ecore_errspecification_test/it/xsemantics/test/errspecification/ecore/validation/TypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/ecore_errspecification_test/it/xsemantics/test/errspecification/ecore/validation/TypeSystemValidator.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.errspecification.ecore.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/test-gen/ecore_expressions_test/it/xsemantics/test/expressions/ecore/TypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/ecore_expressions_test/it/xsemantics/test/expressions/ecore/TypeSystem.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.expressions.ecore;
 
 import com.google.common.base.Objects;

--- a/tests/it.xsemantics.dsl.tests/test-gen/ecore_expressions_test/it/xsemantics/test/expressions/ecore/TypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/ecore_expressions_test/it/xsemantics/test/expressions/ecore/TypeSystem.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.expressions.ecore;
 
 import com.google.common.base.Objects;
@@ -15,14 +25,7 @@ import org.eclipse.xtext.util.PolymorphicDispatcher;
 import org.eclipse.xtext.xbase.lib.StringExtensions;
 
 /**
- * Copyright (c) 2013-2017 Lorenzo Bettini.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- * 
- * Contributors:
- *   Lorenzo Bettini - Initial contribution and API
+ * some particular cases
  */
 @SuppressWarnings("all")
 public class TypeSystem extends XsemanticsRuntimeSystem {

--- a/tests/it.xsemantics.dsl.tests/test-gen/ecore_expressions_test/it/xsemantics/test/expressions/ecore/validation/TypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/ecore_expressions_test/it/xsemantics/test/expressions/ecore/validation/TypeSystemValidator.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.expressions.ecore.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/test-gen/ecore_expressions_test/it/xsemantics/test/expressions/ecore/validation/TypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/ecore_expressions_test/it/xsemantics/test/expressions/ecore/validation/TypeSystemValidator.java
@@ -1,10 +1,3 @@
-package it.xsemantics.test.expressions.ecore.validation;
-
-import com.google.inject.Inject;
-import it.xsemantics.runtime.validation.XsemanticsValidatorErrorGenerator;
-import it.xsemantics.test.expressions.ecore.TypeSystem;
-import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
-
 /**
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
@@ -14,6 +7,16 @@ import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
  * 
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
+ */
+package it.xsemantics.test.expressions.ecore.validation;
+
+import com.google.inject.Inject;
+import it.xsemantics.runtime.validation.XsemanticsValidatorErrorGenerator;
+import it.xsemantics.test.expressions.ecore.TypeSystem;
+import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
+
+/**
+ * some particular cases
  */
 @SuppressWarnings("all")
 public class TypeSystemValidator extends AbstractDeclarativeValidator {

--- a/tests/it.xsemantics.dsl.tests/test-gen/ecore_or_test/it/xsemantics/test/orexpressions/ecore/TypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/ecore_or_test/it/xsemantics/test/orexpressions/ecore/TypeSystem.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.orexpressions.ecore;
 
 import com.google.common.base.Objects;
@@ -13,14 +23,7 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.util.PolymorphicDispatcher;
 
 /**
- * Copyright (c) 2013-2017 Lorenzo Bettini.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- * 
- * Contributors:
- *   Lorenzo Bettini - Initial contribution and API
+ * some particular cases
  */
 @SuppressWarnings("all")
 public class TypeSystem extends XsemanticsRuntimeSystem {

--- a/tests/it.xsemantics.dsl.tests/test-gen/ecore_or_test/it/xsemantics/test/orexpressions/ecore/TypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/ecore_or_test/it/xsemantics/test/orexpressions/ecore/TypeSystem.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.orexpressions.ecore;
 
 import com.google.common.base.Objects;

--- a/tests/it.xsemantics.dsl.tests/test-gen/ecore_or_test/it/xsemantics/test/orexpressions/ecore/validation/TypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/ecore_or_test/it/xsemantics/test/orexpressions/ecore/validation/TypeSystemValidator.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.orexpressions.ecore.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/test-gen/ecore_or_test/it/xsemantics/test/orexpressions/ecore/validation/TypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/ecore_or_test/it/xsemantics/test/orexpressions/ecore/validation/TypeSystemValidator.java
@@ -1,10 +1,3 @@
-package it.xsemantics.test.orexpressions.ecore.validation;
-
-import com.google.inject.Inject;
-import it.xsemantics.runtime.validation.XsemanticsValidatorErrorGenerator;
-import it.xsemantics.test.orexpressions.ecore.TypeSystem;
-import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
-
 /**
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
@@ -14,6 +7,16 @@ import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
  * 
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
+ */
+package it.xsemantics.test.orexpressions.ecore.validation;
+
+import com.google.inject.Inject;
+import it.xsemantics.runtime.validation.XsemanticsValidatorErrorGenerator;
+import it.xsemantics.test.orexpressions.ecore.TypeSystem;
+import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
+
+/**
+ * some particular cases
  */
 @SuppressWarnings("all")
 public class TypeSystemValidator extends AbstractDeclarativeValidator {

--- a/tests/it.xsemantics.dsl.tests/test-gen/ecore_particular_test/it/xsemantics/test/particular/ecore/TypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/ecore_particular_test/it/xsemantics/test/particular/ecore/TypeSystem.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.particular.ecore;
 
 import com.google.common.base.Objects;
@@ -21,14 +31,7 @@ import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.StringExtensions;
 
 /**
- * Copyright (c) 2013-2017 Lorenzo Bettini.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- * 
- * Contributors:
- *   Lorenzo Bettini - Initial contribution and API
+ * some particular cases
  */
 @SuppressWarnings("all")
 public class TypeSystem extends XsemanticsRuntimeSystem {

--- a/tests/it.xsemantics.dsl.tests/test-gen/ecore_particular_test/it/xsemantics/test/particular/ecore/TypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/ecore_particular_test/it/xsemantics/test/particular/ecore/TypeSystem.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.particular.ecore;
 
 import com.google.common.base.Objects;

--- a/tests/it.xsemantics.dsl.tests/test-gen/ecore_particular_test/it/xsemantics/test/particular/ecore/validation/TypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/ecore_particular_test/it/xsemantics/test/particular/ecore/validation/TypeSystemValidator.java
@@ -1,10 +1,3 @@
-package it.xsemantics.test.particular.ecore.validation;
-
-import com.google.inject.Inject;
-import it.xsemantics.runtime.validation.XsemanticsValidatorErrorGenerator;
-import it.xsemantics.test.particular.ecore.TypeSystem;
-import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
-
 /**
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
@@ -14,6 +7,16 @@ import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
  * 
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
+ */
+package it.xsemantics.test.particular.ecore.validation;
+
+import com.google.inject.Inject;
+import it.xsemantics.runtime.validation.XsemanticsValidatorErrorGenerator;
+import it.xsemantics.test.particular.ecore.TypeSystem;
+import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
+
+/**
+ * some particular cases
  */
 @SuppressWarnings("all")
 public class TypeSystemValidator extends AbstractDeclarativeValidator {

--- a/tests/it.xsemantics.dsl.tests/test-gen/ecore_particular_test/it/xsemantics/test/particular/ecore/validation/TypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/ecore_particular_test/it/xsemantics/test/particular/ecore/validation/TypeSystemValidator.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.particular.ecore.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/test-gen/ecore_ruleinvocation_test/it/xsemantics/test/ruleinvocation/ecore/TypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/ecore_ruleinvocation_test/it/xsemantics/test/ruleinvocation/ecore/TypeSystem.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.ruleinvocation.ecore;
 
 import com.google.common.base.Objects;

--- a/tests/it.xsemantics.dsl.tests/test-gen/ecore_ruleinvocation_test/it/xsemantics/test/ruleinvocation/ecore/TypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/ecore_ruleinvocation_test/it/xsemantics/test/ruleinvocation/ecore/TypeSystem.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.ruleinvocation.ecore;
 
 import com.google.common.base.Objects;
@@ -16,16 +26,6 @@ import org.eclipse.emf.ecore.EcoreFactory;
 import org.eclipse.xtext.util.PolymorphicDispatcher;
 import org.eclipse.xtext.xbase.lib.StringExtensions;
 
-/**
- * Copyright (c) 2013-2017 Lorenzo Bettini.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- * 
- * Contributors:
- *   Lorenzo Bettini - Initial contribution and API
- */
 @SuppressWarnings("all")
 public class TypeSystem extends XsemanticsRuntimeSystem {
   public final static String ECLASSEOBJECT = "it.xsemantics.test.ruleinvocation.ecore.EClassEObject";

--- a/tests/it.xsemantics.dsl.tests/test-gen/ecore_ruleinvocation_test/it/xsemantics/test/ruleinvocation/ecore/validation/TypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/ecore_ruleinvocation_test/it/xsemantics/test/ruleinvocation/ecore/validation/TypeSystemValidator.java
@@ -1,10 +1,3 @@
-package it.xsemantics.test.ruleinvocation.ecore.validation;
-
-import com.google.inject.Inject;
-import it.xsemantics.runtime.validation.XsemanticsValidatorErrorGenerator;
-import it.xsemantics.test.ruleinvocation.ecore.TypeSystem;
-import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
-
 /**
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
@@ -15,6 +8,13 @@ import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
  */
+package it.xsemantics.test.ruleinvocation.ecore.validation;
+
+import com.google.inject.Inject;
+import it.xsemantics.runtime.validation.XsemanticsValidatorErrorGenerator;
+import it.xsemantics.test.ruleinvocation.ecore.TypeSystem;
+import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
+
 @SuppressWarnings("all")
 public class TypeSystemValidator extends AbstractDeclarativeValidator {
   @Inject

--- a/tests/it.xsemantics.dsl.tests/test-gen/ecore_ruleinvocation_test/it/xsemantics/test/ruleinvocation/ecore/validation/TypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/ecore_ruleinvocation_test/it/xsemantics/test/ruleinvocation/ecore/validation/TypeSystemValidator.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.ruleinvocation.ecore.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/test-gen/ecore_test/it/xsemantics/test/ecore/TypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/ecore_test/it/xsemantics/test/ecore/TypeSystem.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.ecore;
 
 import com.google.common.base.Objects;
@@ -14,16 +24,6 @@ import org.eclipse.emf.ecore.EcoreFactory;
 import org.eclipse.xtext.util.PolymorphicDispatcher;
 import org.eclipse.xtext.xbase.lib.StringExtensions;
 
-/**
- * Copyright (c) 2013-2017 Lorenzo Bettini.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- * 
- * Contributors:
- *   Lorenzo Bettini - Initial contribution and API
- */
 @SuppressWarnings("all")
 public class TypeSystem extends XsemanticsRuntimeSystem {
   public final static String ECLASSEOBJECT = "it.xsemantics.test.ecore.EClassEObject";

--- a/tests/it.xsemantics.dsl.tests/test-gen/ecore_test/it/xsemantics/test/ecore/TypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/ecore_test/it/xsemantics/test/ecore/TypeSystem.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.ecore;
 
 import com.google.common.base.Objects;

--- a/tests/it.xsemantics.dsl.tests/test-gen/ecore_test/it/xsemantics/test/ecore/validation/TypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/ecore_test/it/xsemantics/test/ecore/validation/TypeSystemValidator.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.ecore.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/test-gen/ecore_test/it/xsemantics/test/ecore/validation/TypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/ecore_test/it/xsemantics/test/ecore/validation/TypeSystemValidator.java
@@ -1,10 +1,3 @@
-package it.xsemantics.test.ecore.validation;
-
-import com.google.inject.Inject;
-import it.xsemantics.runtime.validation.XsemanticsValidatorErrorGenerator;
-import it.xsemantics.test.ecore.TypeSystem;
-import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
-
 /**
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
@@ -15,6 +8,13 @@ import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
  */
+package it.xsemantics.test.ecore.validation;
+
+import com.google.inject.Inject;
+import it.xsemantics.runtime.validation.XsemanticsValidatorErrorGenerator;
+import it.xsemantics.test.ecore.TypeSystem;
+import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
+
 @SuppressWarnings("all")
 public class TypeSystemValidator extends AbstractDeclarativeValidator {
   @Inject

--- a/tests/it.xsemantics.dsl.tests/test-gen/ecore_validation_test/it/xsemantics/test/validation/ecore/TypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/ecore_validation_test/it/xsemantics/test/validation/ecore/TypeSystem.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.validation.ecore;
 
 import com.google.common.base.Objects;

--- a/tests/it.xsemantics.dsl.tests/test-gen/ecore_validation_test/it/xsemantics/test/validation/ecore/TypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/ecore_validation_test/it/xsemantics/test/validation/ecore/TypeSystem.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.validation.ecore;
 
 import com.google.common.base.Objects;
@@ -14,14 +24,7 @@ import org.eclipse.xtext.util.PolymorphicDispatcher;
 import org.eclipse.xtext.xbase.lib.StringExtensions;
 
 /**
- * Copyright (c) 2013-2017 Lorenzo Bettini.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- * 
- * Contributors:
- *   Lorenzo Bettini - Initial contribution and API
+ * some particular cases
  */
 @SuppressWarnings("all")
 public class TypeSystem extends XsemanticsRuntimeSystem {

--- a/tests/it.xsemantics.dsl.tests/test-gen/ecore_validation_test/it/xsemantics/test/validation/ecore/validation/TypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/ecore_validation_test/it/xsemantics/test/validation/ecore/validation/TypeSystemValidator.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.validation.ecore.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/test-gen/ecore_validation_test/it/xsemantics/test/validation/ecore/validation/TypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/ecore_validation_test/it/xsemantics/test/validation/ecore/validation/TypeSystemValidator.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.validation.ecore.validation;
 
 import com.google.inject.Inject;
@@ -8,14 +18,7 @@ import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
 import org.eclipse.xtext.validation.Check;
 
 /**
- * Copyright (c) 2013-2017 Lorenzo Bettini.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- * 
- * Contributors:
- *   Lorenzo Bettini - Initial contribution and API
+ * some particular cases
  */
 @SuppressWarnings("all")
 public class TypeSystemValidator extends AbstractDeclarativeValidator {

--- a/tests/it.xsemantics.dsl.tests/test-gen/fj_alt_test/it/xsemantics/test/fj/alt/FjAltTypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/fj_alt_test/it/xsemantics/test/fj/alt/FjAltTypeSystem.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.fj.alt;
 
 import com.google.common.base.Objects;

--- a/tests/it.xsemantics.dsl.tests/test-gen/fj_alt_test/it/xsemantics/test/fj/alt/FjAltTypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/fj_alt_test/it/xsemantics/test/fj/alt/FjAltTypeSystem.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.fj.alt;
 
 import com.google.common.base.Objects;

--- a/tests/it.xsemantics.dsl.tests/test-gen/fj_alt_test/it/xsemantics/test/fj/alt/validation/FjAltTypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/fj_alt_test/it/xsemantics/test/fj/alt/validation/FjAltTypeSystemValidator.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.fj.alt.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/test-gen/fj_alt_test/it/xsemantics/test/fj/alt/validation/FjAltTypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/fj_alt_test/it/xsemantics/test/fj/alt/validation/FjAltTypeSystemValidator.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.fj.alt.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/test-gen/fj_cached_options_test/it/xsemantics/test/fj/caching/FjFirstCachedOptionsTypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/fj_cached_options_test/it/xsemantics/test/fj/caching/FjFirstCachedOptionsTypeSystem.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.fj.caching;
 
 import it.xsemantics.example.fj.fj.BasicType;

--- a/tests/it.xsemantics.dsl.tests/test-gen/fj_cached_options_test/it/xsemantics/test/fj/caching/FjFirstCachedOptionsTypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/fj_cached_options_test/it/xsemantics/test/fj/caching/FjFirstCachedOptionsTypeSystem.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.fj.caching;
 
 import it.xsemantics.example.fj.fj.BasicType;

--- a/tests/it.xsemantics.dsl.tests/test-gen/fj_cached_options_test/it/xsemantics/test/fj/caching/validation/FjFirstCachedOptionsTypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/fj_cached_options_test/it/xsemantics/test/fj/caching/validation/FjFirstCachedOptionsTypeSystemValidator.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.fj.caching.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/test-gen/fj_cached_options_test/it/xsemantics/test/fj/caching/validation/FjFirstCachedOptionsTypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/fj_cached_options_test/it/xsemantics/test/fj/caching/validation/FjFirstCachedOptionsTypeSystemValidator.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.fj.caching.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/test-gen/fj_cached_test/it/xsemantics/test/fj/caching/FjFirstCachedTypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/fj_cached_test/it/xsemantics/test/fj/caching/FjFirstCachedTypeSystem.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.fj.caching;
 
 import it.xsemantics.example.fj.fj.Expression;

--- a/tests/it.xsemantics.dsl.tests/test-gen/fj_cached_test/it/xsemantics/test/fj/caching/FjFirstCachedTypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/fj_cached_test/it/xsemantics/test/fj/caching/FjFirstCachedTypeSystem.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.fj.caching;
 
 import it.xsemantics.example.fj.fj.Expression;

--- a/tests/it.xsemantics.dsl.tests/test-gen/fj_cached_test/it/xsemantics/test/fj/caching/validation/FjFirstCachedTypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/fj_cached_test/it/xsemantics/test/fj/caching/validation/FjFirstCachedTypeSystemValidator.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.fj.caching.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/test-gen/fj_cached_test/it/xsemantics/test/fj/caching/validation/FjFirstCachedTypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/fj_cached_test/it/xsemantics/test/fj/caching/validation/FjFirstCachedTypeSystemValidator.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.fj.caching.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/test-gen/fj_first_test/it/xsemantics/test/fj/first/FjFirstTypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/fj_first_test/it/xsemantics/test/fj/first/FjFirstTypeSystem.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.fj.first;
 
 import com.google.common.base.Objects;

--- a/tests/it.xsemantics.dsl.tests/test-gen/fj_first_test/it/xsemantics/test/fj/first/FjFirstTypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/fj_first_test/it/xsemantics/test/fj/first/FjFirstTypeSystem.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.fj.first;
 
 import com.google.common.base.Objects;

--- a/tests/it.xsemantics.dsl.tests/test-gen/fj_first_test/it/xsemantics/test/fj/first/validation/FjFirstTypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/fj_first_test/it/xsemantics/test/fj/first/validation/FjFirstTypeSystemValidator.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.fj.first.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/test-gen/fj_first_test/it/xsemantics/test/fj/first/validation/FjFirstTypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/fj_first_test/it/xsemantics/test/fj/first/validation/FjFirstTypeSystemValidator.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.fj.first.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/test-gen/fj_lambda_test/it/xsemantics/test/fj/lambda/FjTestsForLambdas.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/fj_lambda_test/it/xsemantics/test/fj/lambda/FjTestsForLambdas.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.fj.lambda;
 
 import com.google.inject.Inject;
@@ -17,14 +27,7 @@ import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.ListExtensions;
 
 /**
- * Copyright (c) 2013-2017 Lorenzo Bettini.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- * 
- * Contributors:
- *   Lorenzo Bettini - Initial contribution and API
+ * Uses rule invocations as boolean expressions
  */
 @SuppressWarnings("all")
 public class FjTestsForLambdas extends FjFirstTypeSystem {

--- a/tests/it.xsemantics.dsl.tests/test-gen/fj_lambda_test/it/xsemantics/test/fj/lambda/FjTestsForLambdas.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/fj_lambda_test/it/xsemantics/test/fj/lambda/FjTestsForLambdas.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.fj.lambda;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/test-gen/fj_lambda_test/it/xsemantics/test/fj/lambda/validation/FjTestsForLambdasValidator.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/fj_lambda_test/it/xsemantics/test/fj/lambda/validation/FjTestsForLambdasValidator.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.fj.lambda.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/test-gen/fj_lambda_test/it/xsemantics/test/fj/lambda/validation/FjTestsForLambdasValidator.java
+++ b/tests/it.xsemantics.dsl.tests/test-gen/fj_lambda_test/it/xsemantics/test/fj/lambda/validation/FjTestsForLambdasValidator.java
@@ -1,9 +1,3 @@
-package it.xsemantics.test.fj.lambda.validation;
-
-import com.google.inject.Inject;
-import it.xsemantics.test.fj.first.validation.FjFirstTypeSystemValidator;
-import it.xsemantics.test.fj.lambda.FjTestsForLambdas;
-
 /**
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
@@ -13,6 +7,15 @@ import it.xsemantics.test.fj.lambda.FjTestsForLambdas;
  * 
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
+ */
+package it.xsemantics.test.fj.lambda.validation;
+
+import com.google.inject.Inject;
+import it.xsemantics.test.fj.first.validation.FjFirstTypeSystemValidator;
+import it.xsemantics.test.fj.lambda.FjTestsForLambdas;
+
+/**
+ * Uses rule invocations as boolean expressions
  */
 @SuppressWarnings("all")
 public class FjTestsForLambdasValidator extends FjFirstTypeSystemValidator {

--- a/tests/it.xsemantics.dsl.tests/tests_input_files/ecore_errspecification_test.xsemantics
+++ b/tests/it.xsemantics.dsl.tests/tests_input_files/ecore_errspecification_test.xsemantics
@@ -16,6 +16,17 @@ import org.eclipse.emf.ecore.EObject
 
 system it.xsemantics.test.errspecification.ecore.TypeSystem
 
+copyright
+"Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API"
+
+
 judgments {
 	type |- EObject c : output EClass
 		error "cannot find " + c + "'s EClass"

--- a/tests/it.xsemantics.dsl.tests/tests_input_files/ecore_errspecification_test.xsemantics
+++ b/tests/it.xsemantics.dsl.tests/tests_input_files/ecore_errspecification_test.xsemantics
@@ -17,14 +17,16 @@ import org.eclipse.emf.ecore.EObject
 system it.xsemantics.test.errspecification.ecore.TypeSystem
 
 copyright
-"Copyright (c) 2013-2017 Lorenzo Bettini.
-All rights reserved. This program and the accompanying materials
-are made available under the terms of the Eclipse Public License v1.0
-which accompanies this distribution, and is available at
-http://www.eclipse.org/legal/epl-v10.html
-
-Contributors:
-  Lorenzo Bettini - Initial contribution and API"
+"/*******************************************************************************
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ *******************************************************************************/"
 
 
 judgments {

--- a/tests/it.xsemantics.dsl.tests/tests_input_files/ecore_expressions_test.xsemantics
+++ b/tests/it.xsemantics.dsl.tests/tests_input_files/ecore_expressions_test.xsemantics
@@ -16,14 +16,16 @@
 system it.xsemantics.test.expressions.ecore.TypeSystem
 
 copyright
-"Copyright (c) 2013-2017 Lorenzo Bettini.
-All rights reserved. This program and the accompanying materials
-are made available under the terms of the Eclipse Public License v1.0
-which accompanies this distribution, and is available at
-http://www.eclipse.org/legal/epl-v10.html
-
-Contributors:
-  Lorenzo Bettini - Initial contribution and API"
+"/*******************************************************************************
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ *******************************************************************************/"
 
 
 import org.eclipse.emf.ecore.EClass

--- a/tests/it.xsemantics.dsl.tests/tests_input_files/ecore_expressions_test.xsemantics
+++ b/tests/it.xsemantics.dsl.tests/tests_input_files/ecore_expressions_test.xsemantics
@@ -9,9 +9,22 @@
  *   Lorenzo Bettini - Initial contribution and API
  *******************************************************************************/
 
-// some expression cases
 
+/**
+ * some particular cases
+ */
 system it.xsemantics.test.expressions.ecore.TypeSystem
+
+copyright
+"Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API"
+
 
 import org.eclipse.emf.ecore.EClass
 import org.eclipse.emf.ecore.EObject

--- a/tests/it.xsemantics.dsl.tests/tests_input_files/ecore_or_test.xsemantics
+++ b/tests/it.xsemantics.dsl.tests/tests_input_files/ecore_or_test.xsemantics
@@ -9,9 +9,21 @@
  *   Lorenzo Bettini - Initial contribution and API
  *******************************************************************************/
 
-// some particular cases
-
+/**
+ * some particular cases
+ */
 system it.xsemantics.test.orexpressions.ecore.TypeSystem
+
+copyright
+"Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API"
+
 
 import org.eclipse.emf.ecore.EClass
 import org.eclipse.emf.ecore.EObject

--- a/tests/it.xsemantics.dsl.tests/tests_input_files/ecore_or_test.xsemantics
+++ b/tests/it.xsemantics.dsl.tests/tests_input_files/ecore_or_test.xsemantics
@@ -15,14 +15,16 @@
 system it.xsemantics.test.orexpressions.ecore.TypeSystem
 
 copyright
-"Copyright (c) 2013-2017 Lorenzo Bettini.
-All rights reserved. This program and the accompanying materials
-are made available under the terms of the Eclipse Public License v1.0
-which accompanies this distribution, and is available at
-http://www.eclipse.org/legal/epl-v10.html
-
-Contributors:
-  Lorenzo Bettini - Initial contribution and API"
+"/*******************************************************************************
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ *******************************************************************************/"
 
 
 import org.eclipse.emf.ecore.EClass

--- a/tests/it.xsemantics.dsl.tests/tests_input_files/ecore_particular_test.xsemantics
+++ b/tests/it.xsemantics.dsl.tests/tests_input_files/ecore_particular_test.xsemantics
@@ -16,14 +16,16 @@
 system it.xsemantics.test.particular.ecore.TypeSystem
 
 copyright
-"Copyright (c) 2013-2017 Lorenzo Bettini.
-All rights reserved. This program and the accompanying materials
-are made available under the terms of the Eclipse Public License v1.0
-which accompanies this distribution, and is available at
-http://www.eclipse.org/legal/epl-v10.html
-
-Contributors:
-  Lorenzo Bettini - Initial contribution and API"
+"/*******************************************************************************
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ *******************************************************************************/"
 
 
 import java.util.List

--- a/tests/it.xsemantics.dsl.tests/tests_input_files/ecore_particular_test.xsemantics
+++ b/tests/it.xsemantics.dsl.tests/tests_input_files/ecore_particular_test.xsemantics
@@ -9,9 +9,22 @@
  *   Lorenzo Bettini - Initial contribution and API
  *******************************************************************************/
 
-// some particular cases
 
+/**
+ * some particular cases
+ */
 system it.xsemantics.test.particular.ecore.TypeSystem
+
+copyright
+"Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API"
+
 
 import java.util.List
 import org.eclipse.emf.ecore.EClass

--- a/tests/it.xsemantics.dsl.tests/tests_input_files/ecore_ruleinvocation_test.xsemantics
+++ b/tests/it.xsemantics.dsl.tests/tests_input_files/ecore_ruleinvocation_test.xsemantics
@@ -9,7 +9,21 @@
  *   Lorenzo Bettini - Initial contribution and API
  *******************************************************************************/
 
+/**
+ *
+ */
 system it.xsemantics.test.ruleinvocation.ecore.TypeSystem
+
+copyright
+"Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API"
+
 
 import org.eclipse.emf.ecore.EClass
 import org.eclipse.emf.ecore.EObject

--- a/tests/it.xsemantics.dsl.tests/tests_input_files/ecore_ruleinvocation_test.xsemantics
+++ b/tests/it.xsemantics.dsl.tests/tests_input_files/ecore_ruleinvocation_test.xsemantics
@@ -15,14 +15,16 @@
 system it.xsemantics.test.ruleinvocation.ecore.TypeSystem
 
 copyright
-"Copyright (c) 2013-2017 Lorenzo Bettini.
-All rights reserved. This program and the accompanying materials
-are made available under the terms of the Eclipse Public License v1.0
-which accompanies this distribution, and is available at
-http://www.eclipse.org/legal/epl-v10.html
-
-Contributors:
-  Lorenzo Bettini - Initial contribution and API"
+"/*******************************************************************************
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ *******************************************************************************/"
 
 
 import org.eclipse.emf.ecore.EClass

--- a/tests/it.xsemantics.dsl.tests/tests_input_files/ecore_test.xsemantics
+++ b/tests/it.xsemantics.dsl.tests/tests_input_files/ecore_test.xsemantics
@@ -9,7 +9,21 @@
  *   Lorenzo Bettini - Initial contribution and API
  *******************************************************************************/
 
+/**
+ *
+ */
 system it.xsemantics.test.ecore.TypeSystem
+
+copyright
+"Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API"
+
 
 import org.eclipse.emf.ecore.EClass
 import org.eclipse.emf.ecore.EObject

--- a/tests/it.xsemantics.dsl.tests/tests_input_files/ecore_test.xsemantics
+++ b/tests/it.xsemantics.dsl.tests/tests_input_files/ecore_test.xsemantics
@@ -15,14 +15,16 @@
 system it.xsemantics.test.ecore.TypeSystem
 
 copyright
-"Copyright (c) 2013-2017 Lorenzo Bettini.
-All rights reserved. This program and the accompanying materials
-are made available under the terms of the Eclipse Public License v1.0
-which accompanies this distribution, and is available at
-http://www.eclipse.org/legal/epl-v10.html
-
-Contributors:
-  Lorenzo Bettini - Initial contribution and API"
+"/*******************************************************************************
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ *******************************************************************************/"
 
 
 import org.eclipse.emf.ecore.EClass

--- a/tests/it.xsemantics.dsl.tests/tests_input_files/ecore_validation_test.xsemantics
+++ b/tests/it.xsemantics.dsl.tests/tests_input_files/ecore_validation_test.xsemantics
@@ -16,14 +16,16 @@
 system it.xsemantics.test.validation.ecore.TypeSystem
 
 copyright
-"Copyright (c) 2013-2017 Lorenzo Bettini.
-All rights reserved. This program and the accompanying materials
-are made available under the terms of the Eclipse Public License v1.0
-which accompanies this distribution, and is available at
-http://www.eclipse.org/legal/epl-v10.html
-
-Contributors:
-  Lorenzo Bettini - Initial contribution and API"
+"/*******************************************************************************
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ *******************************************************************************/"
 
 
 import org.eclipse.emf.ecore.EClass

--- a/tests/it.xsemantics.dsl.tests/tests_input_files/ecore_validation_test.xsemantics
+++ b/tests/it.xsemantics.dsl.tests/tests_input_files/ecore_validation_test.xsemantics
@@ -9,9 +9,22 @@
  *   Lorenzo Bettini - Initial contribution and API
  *******************************************************************************/
 
-// some particular cases
 
+/**
+ * some particular cases
+ */
 system it.xsemantics.test.validation.ecore.TypeSystem
+
+copyright
+"Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API"
+
 
 import org.eclipse.emf.ecore.EClass
 import org.eclipse.emf.ecore.EObject

--- a/tests/it.xsemantics.dsl.tests/tests_input_files/fj_alt_test.xsemantics
+++ b/tests/it.xsemantics.dsl.tests/tests_input_files/fj_alt_test.xsemantics
@@ -25,6 +25,17 @@ import java.util.List
  */
 system it.xsemantics.test.fj.alt.FjAltTypeSystem extends FjFirstTypeSystem
 
+copyright
+"Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API"
+
+
 inject FjAuxiliaryFunctions fjAux
 
 judgments {

--- a/tests/it.xsemantics.dsl.tests/tests_input_files/fj_alt_test.xsemantics
+++ b/tests/it.xsemantics.dsl.tests/tests_input_files/fj_alt_test.xsemantics
@@ -26,14 +26,16 @@ import java.util.List
 system it.xsemantics.test.fj.alt.FjAltTypeSystem extends FjFirstTypeSystem
 
 copyright
-"Copyright (c) 2013-2017 Lorenzo Bettini.
-All rights reserved. This program and the accompanying materials
-are made available under the terms of the Eclipse Public License v1.0
-which accompanies this distribution, and is available at
-http://www.eclipse.org/legal/epl-v10.html
-
-Contributors:
-  Lorenzo Bettini - Initial contribution and API"
+"/*******************************************************************************
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ *******************************************************************************/"
 
 
 inject FjAuxiliaryFunctions fjAux

--- a/tests/it.xsemantics.dsl.tests/tests_input_files/fj_cached_options_test.xsemantics
+++ b/tests/it.xsemantics.dsl.tests/tests_input_files/fj_cached_options_test.xsemantics
@@ -17,6 +17,17 @@ import it.xsemantics.example.fj.fj.BasicType
 
 system it.xsemantics.test.fj.caching.FjFirstCachedOptionsTypeSystem extends FjFirstCachedTypeSystem
 
+copyright
+"Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API"
+
+
 judgments {
 	override subclass |- Class candidate <| Class superclass cached { entryPoints=NONE }
 	override subtype |- Type left <: Type right cached {

--- a/tests/it.xsemantics.dsl.tests/tests_input_files/fj_cached_options_test.xsemantics
+++ b/tests/it.xsemantics.dsl.tests/tests_input_files/fj_cached_options_test.xsemantics
@@ -18,14 +18,16 @@ import it.xsemantics.example.fj.fj.BasicType
 system it.xsemantics.test.fj.caching.FjFirstCachedOptionsTypeSystem extends FjFirstCachedTypeSystem
 
 copyright
-"Copyright (c) 2013-2017 Lorenzo Bettini.
-All rights reserved. This program and the accompanying materials
-are made available under the terms of the Eclipse Public License v1.0
-which accompanies this distribution, and is available at
-http://www.eclipse.org/legal/epl-v10.html
-
-Contributors:
-  Lorenzo Bettini - Initial contribution and API"
+"/*******************************************************************************
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ *******************************************************************************/"
 
 
 judgments {

--- a/tests/it.xsemantics.dsl.tests/tests_input_files/fj_cached_test.xsemantics
+++ b/tests/it.xsemantics.dsl.tests/tests_input_files/fj_cached_test.xsemantics
@@ -22,6 +22,17 @@ import java.util.List
 
 system it.xsemantics.test.fj.caching.FjFirstCachedTypeSystem extends FjFirstTypeSystem
 
+copyright
+"Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API"
+
+
 auxiliary {
 	override superclasses(Class cl) : List<Class> cached
 }

--- a/tests/it.xsemantics.dsl.tests/tests_input_files/fj_cached_test.xsemantics
+++ b/tests/it.xsemantics.dsl.tests/tests_input_files/fj_cached_test.xsemantics
@@ -23,14 +23,16 @@ import java.util.List
 system it.xsemantics.test.fj.caching.FjFirstCachedTypeSystem extends FjFirstTypeSystem
 
 copyright
-"Copyright (c) 2013-2017 Lorenzo Bettini.
-All rights reserved. This program and the accompanying materials
-are made available under the terms of the Eclipse Public License v1.0
-which accompanies this distribution, and is available at
-http://www.eclipse.org/legal/epl-v10.html
-
-Contributors:
-  Lorenzo Bettini - Initial contribution and API"
+"/*******************************************************************************
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ *******************************************************************************/"
 
 
 auxiliary {

--- a/tests/it.xsemantics.dsl.tests/tests_input_files/fj_first_test.xsemantics
+++ b/tests/it.xsemantics.dsl.tests/tests_input_files/fj_first_test.xsemantics
@@ -40,14 +40,16 @@ import org.eclipse.xtext.EcoreUtil2
 system it.xsemantics.test.fj.first.FjFirstTypeSystem
 
 copyright
-"Copyright (c) 2013-2017 Lorenzo Bettini.
-All rights reserved. This program and the accompanying materials
-are made available under the terms of the Eclipse Public License v1.0
-which accompanies this distribution, and is available at
-http://www.eclipse.org/legal/epl-v10.html
-
-Contributors:
-  Lorenzo Bettini - Initial contribution and API"
+"/*******************************************************************************
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ *******************************************************************************/"
 
 
 validatorExtends AbstractFJJavaValidator

--- a/tests/it.xsemantics.dsl.tests/tests_input_files/fj_first_test.xsemantics
+++ b/tests/it.xsemantics.dsl.tests/tests_input_files/fj_first_test.xsemantics
@@ -39,6 +39,17 @@ import org.eclipse.xtext.EcoreUtil2
 
 system it.xsemantics.test.fj.first.FjFirstTypeSystem
 
+copyright
+"Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API"
+
+
 validatorExtends AbstractFJJavaValidator
 
 inject FjTypeUtils fjTypeUtils

--- a/tests/it.xsemantics.dsl.tests/tests_input_files/fj_lambda_test.xsemantics
+++ b/tests/it.xsemantics.dsl.tests/tests_input_files/fj_lambda_test.xsemantics
@@ -15,14 +15,16 @@
 system it.xsemantics.test.fj.lambda.FjTestsForLambdas extends it.xsemantics.test.fj.first.FjFirstTypeSystem
 
 copyright
-"Copyright (c) 2013-2017 Lorenzo Bettini.
-All rights reserved. This program and the accompanying materials
-are made available under the terms of the Eclipse Public License v1.0
-which accompanies this distribution, and is available at
-http://www.eclipse.org/legal/epl-v10.html
-
-Contributors:
-  Lorenzo Bettini - Initial contribution and API"
+"/*******************************************************************************
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ *******************************************************************************/"
 
 
 import it.xsemantics.example.fj.fj.ClassType

--- a/tests/it.xsemantics.dsl.tests/tests_input_files/fj_lambda_test.xsemantics
+++ b/tests/it.xsemantics.dsl.tests/tests_input_files/fj_lambda_test.xsemantics
@@ -9,9 +9,21 @@
  *   Lorenzo Bettini - Initial contribution and API
  *******************************************************************************/
 
-// Uses rule invocations as boolean expressions
-
+/**
+ * Uses rule invocations as boolean expressions
+ */
 system it.xsemantics.test.fj.lambda.FjTestsForLambdas extends it.xsemantics.test.fj.first.FjFirstTypeSystem
+
+copyright
+"Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API"
+
 
 import it.xsemantics.example.fj.fj.ClassType
 import it.xsemantics.example.fj.fj.Type

--- a/tests/it.xsemantics.dsl.tests/tests_input_files_with_errors/ecore_test_errors.xsemantics
+++ b/tests/it.xsemantics.dsl.tests/tests_input_files_with_errors/ecore_test_errors.xsemantics
@@ -14,6 +14,17 @@
 
 system it.xsemantics.test.ecore.TypeSystem
 
+copyright
+"Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API"
+
+
 import org.eclipse.emf.ecore.EClass
 import org.eclipse.emf.ecore.EObject
 import org.eclipse.emf.ecore.EcoreFactory

--- a/tests/it.xsemantics.dsl.tests/tests_performance_input_files/PerformanceTest.xsemantics
+++ b/tests/it.xsemantics.dsl.tests/tests_performance_input_files/PerformanceTest.xsemantics
@@ -11,6 +11,17 @@
 
 system it.xsemantics.test.performance.System
 
+copyright
+"Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API"
+
+
 import org.eclipse.emf.ecore.EClass
 import org.eclipse.emf.ecore.EObject
 import org.eclipse.emf.ecore.EcoreFactory

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/ecore/TypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/ecore/TypeSystem.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.ecore;
 
 import com.google.common.base.Objects;
@@ -14,16 +24,6 @@ import org.eclipse.emf.ecore.EcoreFactory;
 import org.eclipse.xtext.util.PolymorphicDispatcher;
 import org.eclipse.xtext.xbase.lib.StringExtensions;
 
-/**
- * Copyright (c) 2013-2017 Lorenzo Bettini.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- * 
- * Contributors:
- *   Lorenzo Bettini - Initial contribution and API
- */
 @SuppressWarnings("all")
 public class TypeSystem extends XsemanticsRuntimeSystem {
   public final static String ECLASSEOBJECT = "it.xsemantics.test.ecore.EClassEObject";

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/ecore/TypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/ecore/TypeSystem.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.ecore;
 
 import com.google.common.base.Objects;

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/ecore/validation/TypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/ecore/validation/TypeSystemValidator.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.ecore.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/ecore/validation/TypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/ecore/validation/TypeSystemValidator.java
@@ -1,10 +1,3 @@
-package it.xsemantics.test.ecore.validation;
-
-import com.google.inject.Inject;
-import it.xsemantics.runtime.validation.XsemanticsValidatorErrorGenerator;
-import it.xsemantics.test.ecore.TypeSystem;
-import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
-
 /**
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
@@ -15,6 +8,13 @@ import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
  */
+package it.xsemantics.test.ecore.validation;
+
+import com.google.inject.Inject;
+import it.xsemantics.runtime.validation.XsemanticsValidatorErrorGenerator;
+import it.xsemantics.test.ecore.TypeSystem;
+import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
+
 @SuppressWarnings("all")
 public class TypeSystemValidator extends AbstractDeclarativeValidator {
   @Inject

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/errspecification/ecore/TypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/errspecification/ecore/TypeSystem.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.errspecification.ecore;
 
 import com.google.inject.Provider;

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/errspecification/ecore/TypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/errspecification/ecore/TypeSystem.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.errspecification.ecore;
 
 import com.google.inject.Provider;

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/errspecification/ecore/validation/TypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/errspecification/ecore/validation/TypeSystemValidator.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.errspecification.ecore.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/errspecification/ecore/validation/TypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/errspecification/ecore/validation/TypeSystemValidator.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.errspecification.ecore.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/expressions/ecore/TypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/expressions/ecore/TypeSystem.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.expressions.ecore;
 
 import com.google.common.base.Objects;

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/expressions/ecore/TypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/expressions/ecore/TypeSystem.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.expressions.ecore;
 
 import com.google.common.base.Objects;
@@ -15,14 +25,7 @@ import org.eclipse.xtext.util.PolymorphicDispatcher;
 import org.eclipse.xtext.xbase.lib.StringExtensions;
 
 /**
- * Copyright (c) 2013-2017 Lorenzo Bettini.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- * 
- * Contributors:
- *   Lorenzo Bettini - Initial contribution and API
+ * some particular cases
  */
 @SuppressWarnings("all")
 public class TypeSystem extends XsemanticsRuntimeSystem {

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/expressions/ecore/validation/TypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/expressions/ecore/validation/TypeSystemValidator.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.expressions.ecore.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/expressions/ecore/validation/TypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/expressions/ecore/validation/TypeSystemValidator.java
@@ -1,10 +1,3 @@
-package it.xsemantics.test.expressions.ecore.validation;
-
-import com.google.inject.Inject;
-import it.xsemantics.runtime.validation.XsemanticsValidatorErrorGenerator;
-import it.xsemantics.test.expressions.ecore.TypeSystem;
-import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
-
 /**
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
@@ -14,6 +7,16 @@ import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
  * 
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
+ */
+package it.xsemantics.test.expressions.ecore.validation;
+
+import com.google.inject.Inject;
+import it.xsemantics.runtime.validation.XsemanticsValidatorErrorGenerator;
+import it.xsemantics.test.expressions.ecore.TypeSystem;
+import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
+
+/**
+ * some particular cases
  */
 @SuppressWarnings("all")
 public class TypeSystemValidator extends AbstractDeclarativeValidator {

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/fj/alt/FjAltTypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/fj/alt/FjAltTypeSystem.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.fj.alt;
 
 import com.google.common.base.Objects;

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/fj/alt/FjAltTypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/fj/alt/FjAltTypeSystem.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.fj.alt;
 
 import com.google.common.base.Objects;

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/fj/alt/validation/FjAltTypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/fj/alt/validation/FjAltTypeSystemValidator.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.fj.alt.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/fj/alt/validation/FjAltTypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/fj/alt/validation/FjAltTypeSystemValidator.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.fj.alt.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/fj/caching/FjFirstCachedOptionsTypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/fj/caching/FjFirstCachedOptionsTypeSystem.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.fj.caching;
 
 import it.xsemantics.example.fj.fj.BasicType;

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/fj/caching/FjFirstCachedOptionsTypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/fj/caching/FjFirstCachedOptionsTypeSystem.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.fj.caching;
 
 import it.xsemantics.example.fj.fj.BasicType;

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/fj/caching/FjFirstCachedTypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/fj/caching/FjFirstCachedTypeSystem.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.fj.caching;
 
 import it.xsemantics.example.fj.fj.Expression;

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/fj/caching/FjFirstCachedTypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/fj/caching/FjFirstCachedTypeSystem.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.fj.caching;
 
 import it.xsemantics.example.fj.fj.Expression;

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/fj/caching/validation/FjFirstCachedOptionsTypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/fj/caching/validation/FjFirstCachedOptionsTypeSystemValidator.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.fj.caching.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/fj/caching/validation/FjFirstCachedOptionsTypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/fj/caching/validation/FjFirstCachedOptionsTypeSystemValidator.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.fj.caching.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/fj/caching/validation/FjFirstCachedTypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/fj/caching/validation/FjFirstCachedTypeSystemValidator.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.fj.caching.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/fj/caching/validation/FjFirstCachedTypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/fj/caching/validation/FjFirstCachedTypeSystemValidator.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.fj.caching.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/fj/first/FjFirstTypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/fj/first/FjFirstTypeSystem.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.fj.first;
 
 import com.google.common.base.Objects;

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/fj/first/FjFirstTypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/fj/first/FjFirstTypeSystem.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.fj.first;
 
 import com.google.common.base.Objects;

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/fj/first/validation/FjFirstTypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/fj/first/validation/FjFirstTypeSystemValidator.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.fj.first.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/fj/first/validation/FjFirstTypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/fj/first/validation/FjFirstTypeSystemValidator.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.fj.first.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/fj/lambda/FjTestsForLambdas.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/fj/lambda/FjTestsForLambdas.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.fj.lambda;
 
 import com.google.inject.Inject;
@@ -17,14 +27,7 @@ import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.ListExtensions;
 
 /**
- * Copyright (c) 2013-2017 Lorenzo Bettini.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- * 
- * Contributors:
- *   Lorenzo Bettini - Initial contribution and API
+ * Uses rule invocations as boolean expressions
  */
 @SuppressWarnings("all")
 public class FjTestsForLambdas extends FjFirstTypeSystem {

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/fj/lambda/FjTestsForLambdas.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/fj/lambda/FjTestsForLambdas.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.fj.lambda;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/fj/lambda/validation/FjTestsForLambdasValidator.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/fj/lambda/validation/FjTestsForLambdasValidator.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.fj.lambda.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/fj/lambda/validation/FjTestsForLambdasValidator.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/fj/lambda/validation/FjTestsForLambdasValidator.java
@@ -1,9 +1,3 @@
-package it.xsemantics.test.fj.lambda.validation;
-
-import com.google.inject.Inject;
-import it.xsemantics.test.fj.first.validation.FjFirstTypeSystemValidator;
-import it.xsemantics.test.fj.lambda.FjTestsForLambdas;
-
 /**
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
@@ -13,6 +7,15 @@ import it.xsemantics.test.fj.lambda.FjTestsForLambdas;
  * 
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
+ */
+package it.xsemantics.test.fj.lambda.validation;
+
+import com.google.inject.Inject;
+import it.xsemantics.test.fj.first.validation.FjFirstTypeSystemValidator;
+import it.xsemantics.test.fj.lambda.FjTestsForLambdas;
+
+/**
+ * Uses rule invocations as boolean expressions
  */
 @SuppressWarnings("all")
 public class FjTestsForLambdasValidator extends FjFirstTypeSystemValidator {

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/orexpressions/ecore/TypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/orexpressions/ecore/TypeSystem.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.orexpressions.ecore;
 
 import com.google.common.base.Objects;
@@ -13,14 +23,7 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.util.PolymorphicDispatcher;
 
 /**
- * Copyright (c) 2013-2017 Lorenzo Bettini.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- * 
- * Contributors:
- *   Lorenzo Bettini - Initial contribution and API
+ * some particular cases
  */
 @SuppressWarnings("all")
 public class TypeSystem extends XsemanticsRuntimeSystem {

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/orexpressions/ecore/TypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/orexpressions/ecore/TypeSystem.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.orexpressions.ecore;
 
 import com.google.common.base.Objects;

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/orexpressions/ecore/validation/TypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/orexpressions/ecore/validation/TypeSystemValidator.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.orexpressions.ecore.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/orexpressions/ecore/validation/TypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/orexpressions/ecore/validation/TypeSystemValidator.java
@@ -1,10 +1,3 @@
-package it.xsemantics.test.orexpressions.ecore.validation;
-
-import com.google.inject.Inject;
-import it.xsemantics.runtime.validation.XsemanticsValidatorErrorGenerator;
-import it.xsemantics.test.orexpressions.ecore.TypeSystem;
-import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
-
 /**
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
@@ -14,6 +7,16 @@ import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
  * 
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
+ */
+package it.xsemantics.test.orexpressions.ecore.validation;
+
+import com.google.inject.Inject;
+import it.xsemantics.runtime.validation.XsemanticsValidatorErrorGenerator;
+import it.xsemantics.test.orexpressions.ecore.TypeSystem;
+import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
+
+/**
+ * some particular cases
  */
 @SuppressWarnings("all")
 public class TypeSystemValidator extends AbstractDeclarativeValidator {

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/particular/ecore/TypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/particular/ecore/TypeSystem.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.particular.ecore;
 
 import com.google.common.base.Objects;
@@ -21,14 +31,7 @@ import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.StringExtensions;
 
 /**
- * Copyright (c) 2013-2017 Lorenzo Bettini.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- * 
- * Contributors:
- *   Lorenzo Bettini - Initial contribution and API
+ * some particular cases
  */
 @SuppressWarnings("all")
 public class TypeSystem extends XsemanticsRuntimeSystem {

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/particular/ecore/TypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/particular/ecore/TypeSystem.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.particular.ecore;
 
 import com.google.common.base.Objects;

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/particular/ecore/validation/TypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/particular/ecore/validation/TypeSystemValidator.java
@@ -1,10 +1,3 @@
-package it.xsemantics.test.particular.ecore.validation;
-
-import com.google.inject.Inject;
-import it.xsemantics.runtime.validation.XsemanticsValidatorErrorGenerator;
-import it.xsemantics.test.particular.ecore.TypeSystem;
-import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
-
 /**
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
@@ -14,6 +7,16 @@ import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
  * 
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
+ */
+package it.xsemantics.test.particular.ecore.validation;
+
+import com.google.inject.Inject;
+import it.xsemantics.runtime.validation.XsemanticsValidatorErrorGenerator;
+import it.xsemantics.test.particular.ecore.TypeSystem;
+import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
+
+/**
+ * some particular cases
  */
 @SuppressWarnings("all")
 public class TypeSystemValidator extends AbstractDeclarativeValidator {

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/particular/ecore/validation/TypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/particular/ecore/validation/TypeSystemValidator.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.particular.ecore.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/ruleinvocation/ecore/TypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/ruleinvocation/ecore/TypeSystem.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.ruleinvocation.ecore;
 
 import com.google.common.base.Objects;

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/ruleinvocation/ecore/TypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/ruleinvocation/ecore/TypeSystem.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.ruleinvocation.ecore;
 
 import com.google.common.base.Objects;
@@ -16,16 +26,6 @@ import org.eclipse.emf.ecore.EcoreFactory;
 import org.eclipse.xtext.util.PolymorphicDispatcher;
 import org.eclipse.xtext.xbase.lib.StringExtensions;
 
-/**
- * Copyright (c) 2013-2017 Lorenzo Bettini.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- * 
- * Contributors:
- *   Lorenzo Bettini - Initial contribution and API
- */
 @SuppressWarnings("all")
 public class TypeSystem extends XsemanticsRuntimeSystem {
   public final static String ECLASSEOBJECT = "it.xsemantics.test.ruleinvocation.ecore.EClassEObject";

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/ruleinvocation/ecore/validation/TypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/ruleinvocation/ecore/validation/TypeSystemValidator.java
@@ -1,10 +1,3 @@
-package it.xsemantics.test.ruleinvocation.ecore.validation;
-
-import com.google.inject.Inject;
-import it.xsemantics.runtime.validation.XsemanticsValidatorErrorGenerator;
-import it.xsemantics.test.ruleinvocation.ecore.TypeSystem;
-import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
-
 /**
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
@@ -15,6 +8,13 @@ import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
  */
+package it.xsemantics.test.ruleinvocation.ecore.validation;
+
+import com.google.inject.Inject;
+import it.xsemantics.runtime.validation.XsemanticsValidatorErrorGenerator;
+import it.xsemantics.test.ruleinvocation.ecore.TypeSystem;
+import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
+
 @SuppressWarnings("all")
 public class TypeSystemValidator extends AbstractDeclarativeValidator {
   @Inject

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/ruleinvocation/ecore/validation/TypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/ruleinvocation/ecore/validation/TypeSystemValidator.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.ruleinvocation.ecore.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/validation/ecore/TypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/validation/ecore/TypeSystem.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.validation.ecore;
 
 import com.google.common.base.Objects;

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/validation/ecore/TypeSystem.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/validation/ecore/TypeSystem.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.validation.ecore;
 
 import com.google.common.base.Objects;
@@ -14,14 +24,7 @@ import org.eclipse.xtext.util.PolymorphicDispatcher;
 import org.eclipse.xtext.xbase.lib.StringExtensions;
 
 /**
- * Copyright (c) 2013-2017 Lorenzo Bettini.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- * 
- * Contributors:
- *   Lorenzo Bettini - Initial contribution and API
+ * some particular cases
  */
 @SuppressWarnings("all")
 public class TypeSystem extends XsemanticsRuntimeSystem {

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/validation/ecore/validation/TypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/validation/ecore/validation/TypeSystemValidator.java
@@ -1,13 +1,13 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2013-2017 Lorenzo Bettini.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * Contributors:
  *   Lorenzo Bettini - Initial contribution and API
- */
+ *******************************************************************************/
 package it.xsemantics.test.validation.ecore.validation;
 
 import com.google.inject.Inject;

--- a/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/validation/ecore/validation/TypeSystemValidator.java
+++ b/tests/it.xsemantics.dsl.tests/xsemantics-gen/it/xsemantics/test/validation/ecore/validation/TypeSystemValidator.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2013-2017 Lorenzo Bettini.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Lorenzo Bettini - Initial contribution and API
+ */
 package it.xsemantics.test.validation.ecore.validation;
 
 import com.google.inject.Inject;
@@ -8,14 +18,7 @@ import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
 import org.eclipse.xtext.validation.Check;
 
 /**
- * Copyright (c) 2013-2017 Lorenzo Bettini.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- * 
- * Contributors:
- *   Lorenzo Bettini - Initial contribution and API
+ * some particular cases
  */
 @SuppressWarnings("all")
 public class TypeSystemValidator extends AbstractDeclarativeValidator {

--- a/tests/it.xsemantics.dsl.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/it.xsemantics.dsl.ui.tests/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Xsemantics UI Tests
 Bundle-SymbolicName: it.xsemantics.dsl.ui.tests
+Bundle-Vendor: %providerName
 Bundle-Version: 1.12.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: it.xsemantics.dsl.ui,

--- a/tests/it.xsemantics.dsl.ui.tests/about.html
+++ b/tests/it.xsemantics.dsl.ui.tests/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>July 11, 2017</p>
+
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/tests/it.xsemantics.dsl.ui.tests/plugin.properties
+++ b/tests/it.xsemantics.dsl.ui.tests/plugin.properties
@@ -1,3 +1,3 @@
 
-pluginName = it.xsemantics.dsl
+pluginName = it.xsemantics.dsl.ui.tests
 providerName = Eclipse Xsemantics Project

--- a/tests/it.xsemantics.dsl.ui.tests/pom.xml
+++ b/tests/it.xsemantics.dsl.ui.tests/pom.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>

--- a/tests/it.xsemantics.example.maven.test/META-INF/MANIFEST.MF
+++ b/tests/it.xsemantics.example.maven.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Xsemantics Test Using Xtext Maven Plugin
 Bundle-SymbolicName: it.xsemantics.example.maven.test
 Bundle-Version: 1.12.1.qualifier
-Bundle-Vendor: Lorenzo Bettini
+Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipse.xtend.lib,
  org.eclipse.xtend.lib.macro,

--- a/tests/it.xsemantics.example.maven.test/about.html
+++ b/tests/it.xsemantics.example.maven.test/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>July 11, 2017</p>
+
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/tests/it.xsemantics.example.maven.test/plugin.properties
+++ b/tests/it.xsemantics.example.maven.test/plugin.properties
@@ -1,0 +1,3 @@
+
+pluginName = it.xsemantics.example.maven.test
+providerName = Eclipse Xsemantics Project

--- a/tests/it.xsemantics.example.maven.test/pom.xml
+++ b/tests/it.xsemantics.example.maven.test/pom.xml
@@ -1,3 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/tests/it.xsemantics.example.maven.test/src/it/xsemantics/example/maven/test/typesystem/MyExtendedTypeSystem.xsemantics
+++ b/tests/it.xsemantics.example.maven.test/src/it/xsemantics/example/maven/test/typesystem/MyExtendedTypeSystem.xsemantics
@@ -13,6 +13,17 @@ import it.xsemantics.example.maven.test.model.MyModel
 
 system it.xsemantics.example.maven.test.typesystem.MyExtendedTypeSystem extends MyModelTypeSystem
 
+copyright
+"Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API"
+
+
 judgments {
 	subtype |- MyModel m1 <: MyModel m2
 		error stringRep(m1) + " is not a subtype of " + stringRep(m2)

--- a/tests/it.xsemantics.example.maven.test/src/it/xsemantics/example/maven/test/typesystem/MyModelTypeSystem.xsemantics
+++ b/tests/it.xsemantics.example.maven.test/src/it/xsemantics/example/maven/test/typesystem/MyModelTypeSystem.xsemantics
@@ -13,6 +13,17 @@ import it.xsemantics.example.maven.test.model.MyModel
 
 system it.xsemantics.example.maven.test.typesystem.MyModelTypeSystem
 
+copyright
+"Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API"
+
+
 judgments {
 	type |- Object expression : output Object
 		error "cannot type " + stringRep(expression)

--- a/tests/it.xsemantics.tests.pde.utils/META-INF/MANIFEST.MF
+++ b/tests/it.xsemantics.tests.pde.utils/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Tests PDE Utils
 Bundle-SymbolicName: it.xsemantics.tests.pde.utils
 Bundle-Version: 1.12.1.qualifier
-Bundle-Vendor: Lorenzo Bettini
+Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipse.pde.core;bundle-version="3.10.0";visibility:=reexport,
  org.eclipse.core.runtime;bundle-version="3.9.100",

--- a/tests/it.xsemantics.tests.pde.utils/about.html
+++ b/tests/it.xsemantics.tests.pde.utils/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>July 11, 2017</p>
+
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/tests/it.xsemantics.tests.pde.utils/plugin.properties
+++ b/tests/it.xsemantics.tests.pde.utils/plugin.properties
@@ -1,3 +1,3 @@
 
-pluginName = it.xsemantics.dsl
+pluginName = it.xsemantics.tests.pde.utils
 providerName = Eclipse Xsemantics Project

--- a/tests/it.xsemantics.tests.pde.utils/pom.xml
+++ b/tests/it.xsemantics.tests.pde.utils/pom.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/tests/it.xsemantics.tests.swtbot/META-INF/MANIFEST.MF
+++ b/tests/it.xsemantics.tests.swtbot/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Xsemantics SWTBOT Tests
 Bundle-SymbolicName: it.xsemantics.tests.swtbot;singleton:=true
 Bundle-Version: 1.12.1.qualifier
 Bundle-ActivationPolicy: lazy
-Bundle-Vendor: Lorenzo Bettini
+Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipse.swtbot.go;bundle-version="2.3.0",
  org.eclipse.core.resources;bundle-version="3.7.100",

--- a/tests/it.xsemantics.tests.swtbot/about.html
+++ b/tests/it.xsemantics.tests.swtbot/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>July 11, 2017</p>
+
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/tests/it.xsemantics.tests.swtbot/plugin.properties
+++ b/tests/it.xsemantics.tests.swtbot/plugin.properties
@@ -1,3 +1,3 @@
 
-pluginName = it.xsemantics.dsl
+pluginName = it.xsemantics.tests.swtbot
 providerName = Eclipse Xsemantics Project

--- a/tests/it.xsemantics.tests.swtbot/pom.xml
+++ b/tests/it.xsemantics.tests.swtbot/pom.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013-2017 Lorenzo Bettini.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+
+Contributors:
+  Lorenzo Bettini - Initial contribution and API
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
After merging these adjustments to branch `master-eclipse`, the FileChecker in the version of branch `mor-temp` in repo `eclipse/n4js` should report only a few complaints.

Remaining complaints:
* missing copyright header / invalid word copyright in all Xsemantics-generated Java files (`TypeSystem.java`, `TypeSystemValidator.java`, etc.) --> should be possible to resolve with fixes from commit https://github.com/mmews-n4/xsemantics/commit/137b415b7cf79bd227b2109a1ca36c7ed2403ff5
* maybe a few more complaints (but should not be more than about 5)


IMPORTANT: the following files need further investigation:
```
/tests/it.xsemantics.dsl.tests/old/XsemanticsOnTheFlyJavaCompiler.java
/tests/it.xsemantics.dsl.ui.tests/src/org/eclipse/xtext/ui/tests/editor/outline/AbstractOutlineWorkbenchTest.java
/tests/it.xsemantics.tests.pde.utils/src/it/xsemantics/tests/pde/utils/PDETargetPlatformUtils.java
```
An EMail was sent to Lorenzo and he has provided a PR related to the above 3 files:
https://github.com/LorenzoBettini/xsemantics/pull/93